### PR TITLE
Teach Identity.hasSession to fall back to spid

### DIFF
--- a/__tests__/.eslintrc.yml
+++ b/__tests__/.eslintrc.yml
@@ -1,5 +1,6 @@
 rules:
     require-jsdoc: 0
 globals:
-    expect: true
     beforeAll: true
+    expect: true
+    jest: true

--- a/src/identity.js
+++ b/src/identity.js
@@ -319,22 +319,12 @@ class Identity extends EventEmitter {
                 return cachedData;
             }
         }
-        // eslint-disable-next-line require-jsdoc
-        const getSessionData = async (autologin) => {
-            try {
-                return await this._hasSession.get('rpc/hasSession.js', { autologin });
-            } catch (err) {
-                // The first call was made to session cluster, try SPiD as well
-                if (isObject(err) && err.type === 'LoginException') {
-                    return await this._spid.get('ajax/hasSession.js', { autologin });
-                }
-                // Rethrow
-                throw err;
-            }
-        }
 
         try {
-            const data = await getSessionData(autologin ? 1 : 0);
+            let data = await this._hasSession.get('rpc/hasSession.js', { autologin });
+            if (isObject(data.error) && data.error.type === 'LoginException') {
+                data = await this._spid.get('ajax/hasSession.js', { autologin });
+            }
             if (data.result) {
                 this.cache.set(HAS_SESSION_CACHE_KEY, data, data.expiresIn * 1000);
             }


### PR DESCRIPTION
Version 2.x of this SDK has a check that if a return value from
hasSession contains an “error” key with child “type”: “LoginException”,
it will repeat the request, but send it directly to SPiD.

There was a bug in this version. A call to fetch only errors when there
is a network error, so the error handling to check for “LoginException”
was placed in the wrong spot. I have moved it, and also created a unit
test to simulate this and verify that such a response from hasSession
should in fact retry the request to SPiD.

Thanks to Terje Andersen for reporting the bug.