### PR TITLE
identity: Send correct autologin parameter

### DIFF
--- a/__mocks__/.eslintrc.yml
+++ b/__mocks__/.eslintrc.yml
@@ -1,0 +1,4 @@
+rules:
+    require-jsdoc: 0
+globals:
+    jest: true

--- a/__mocks__/fetch-jsonp.js
+++ b/__mocks__/fetch-jsonp.js
@@ -1,0 +1,86 @@
+const { URL } = require('url');
+
+const mockHasSessionLoginRequired = {
+    error: {
+        code: 401,
+        type: 'LoginException',
+        description: 'Autologin required'
+    },
+    response: {
+        result: false,
+        serverTime: 1520599943,
+        expiresIn: null,
+        baseDomain: 'localhost',
+        visitor: {
+            uid: 'Xytpn4Xoi8rb9Xso27ks',
+            user_id: '36424'
+        }
+    }
+};
+const mockHasSessionUserException = {
+    error: {
+        code: 401,
+        type: 'UserException',
+        description: 'No session found'
+    },
+    response: {
+        result: false,
+        serverTime: 1520599943,
+        expiresIn: null,
+        baseDomain: 'localhost',
+        visitor: {
+            uid: 'Xytpn4Xoi8rb9Xso27ks',
+            user_id: '36424'
+        }
+    }
+};
+const mockSPiDOk = {
+    result: true,
+    serverTime: 1520610964,
+    expiresIn: 2592000,
+    visitor: {
+        uid: '1234',
+        user_id: '12345'
+    },
+    id: '59e9eaaaacb3ad0aaaedaaaa',
+    userId: 12345,
+    uuid: 'aaaaaaaa-de42-5c4b-80ee-eeeeeeeeeeee',
+    displayName: 'bruce_wayne',
+    givenName: 'Bruce',
+    familyName: 'Wayne',
+    gender: 'withheld',
+    photo: 'https://secure.gravatar.com/avatar/1234?s=200',
+    tracking: true,
+    userStatus: 'connected',
+    clientAgreementAccepted: true,
+    defaultAgreementAccepted: true,
+    sp_id: 'some-jwt-token',
+    sig: 'some-encrypted-value'
+};
+
+const mockFn = jest.fn().mockImplementation(mock);
+
+const mock = async (url) => {
+    const { pathname, searchParams: search } = new URL(url);
+    const autologin = search.get('autologin');
+    if (autologin === 'true') {
+        return { ok: true, json: async () => mockHasSessionLoginRequired };
+    }
+    if (pathname === '/rpc/hasSession.js') { // hasSession
+        if (autologin === '1') {
+            return { ok: true, json: async () => mockHasSessionLoginRequired };
+        } else if (autologin === '0') {
+            return { ok: true, json: async () => mockHasSessionUserException };
+        } else {
+            return { ok: false };
+        }
+    }
+    if (pathname === '/ajax/hasSession.js') { // SPiD
+        return { ok: true, json: async () => mockSPiDOk };
+    }
+    return;
+}
+
+mockFn.mockImplementation(mock);
+
+module.exports = mockFn;

--- a/src/identity.js
+++ b/src/identity.js
@@ -321,9 +321,9 @@ class Identity extends EventEmitter {
         }
 
         try {
-            let data = await this._hasSession.get('rpc/hasSession.js', { autologin });
+            let data = await this._hasSession.get('rpc/hasSession.js', { autologin: autologin ? 1 : 0 });
             if (isObject(data.error) && data.error.type === 'LoginException') {
-                data = await this._spid.get('ajax/hasSession.js', { autologin });
+                data = await this._spid.get('ajax/hasSession.js', { autologin: autologin ? 1 : 0 });
             }
             if (data.result) {
                 this.cache.set(HAS_SESSION_CACHE_KEY, data, data.expiresIn * 1000);


### PR DESCRIPTION
The hasSession and SPiD backends expect the autologin parameter to be
either ‘0’ or ‘1’ (and not false/true). This used to be how the Identity
class worked, but a recent refactoring introduced a bug there.

This commit refactors the unit tests for hasSession, adds tests for
autologin, and fixes the issue.