### PR TITLE
RESTClient: Bind default fetch reference to ‘window’

### DIFF
--- a/__tests__/RESTClient.utest.js
+++ b/__tests__/RESTClient.utest.js
@@ -5,7 +5,7 @@
 'use strict';
 
 const { ENDPOINTS } = require('../src/config');
-const RESTClient = require('../src/RESTClient');
+let RESTClient = require('../src/RESTClient');
 
 describe('RESTClient', () => {
     test('has the REST methods for get and go', () => {
@@ -17,6 +17,21 @@ describe('RESTClient', () => {
 
         expect(typeof restClient.get).toBe('function');
         expect(typeof restClient.go).toBe('function');
+    });
+
+    test('fetch default works', () => {
+        window.fetch = function () {
+            if (this !== window) {
+                throw new Error('Illegal invocation!');
+            }
+        };
+        jest.resetModuleRegistry();
+        RESTClient = require('../src/RESTClient');
+        const restClient = new RESTClient({
+            serverUrl: 'DEV',
+            envDic: ENDPOINTS.SPiD,
+        });
+        expect(restClient.fetch).not.toThrow(/Illegal invocation/);
     });
 
     test('Supplied log function is called', async () => {

--- a/src/RESTClient.js
+++ b/src/RESTClient.js
@@ -45,7 +45,7 @@ function encode(str) {
     return encodeURIComponent(str).replace(/[!'()~]|%20|%00/g, match => replace[match]);
 }
 
-const globalFetch = window.fetch;
+const globalFetch = window.fetch && window.fetch.bind(window);
 
 /**
  * This class can be used for creating a wrapper around a server and all its endpoints.


### PR DESCRIPTION
This issue was only discovered when communicating with the BFF, but
without this commit, the fetch command will fail in certain browsers,
because they need it to be bound to the window instance.