### PR TITLE
npmignore: include source maps for es5 files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,4 +4,5 @@
 !monetization.js
 !payment.js
 !es5/*.js
+!es5/*.js.map
 !src/**/*


### PR DESCRIPTION
Fixes #38

When we generate ES5 compatible files, there were no source maps
included. Should work fine now.