### PR TITLE
Remove refs to ‘window’ from global scope

### DIFF
--- a/src/RESTClient.js
+++ b/src/RESTClient.js
@@ -45,7 +45,8 @@ function encode(str) {
     return encodeURIComponent(str).replace(/[!'()~]|%20|%00/g, match => replace[match]);
 }
 
-const globalFetch = window.fetch && window.fetch.bind(window);
+// eslint-disable-next-line require-jsdoc
+const globalFetch = () => window.fetch && window.fetch.bind(window);
 
 /**
  * This class can be used for creating a wrapper around a server and all its endpoints.
@@ -73,7 +74,7 @@ export class RESTClient {
      * @param {object} [options.defaultParams={}] - a set of parameters to add to every call custom.
      *        As long as it supports the standard fetch API we're good.
      */
-    constructor({ serverUrl = 'PRE', envDic, fetch = globalFetch, log, defaultParams = {}}) {
+    constructor({ serverUrl = 'PRE', envDic, fetch = globalFetch(), log, defaultParams = {}}) {
         assert(isObject(defaultParams), `defaultParams should be a non-null object`);
 
         this.url = new URL(urlMapper(serverUrl, envDic));

--- a/src/identity.js
+++ b/src/identity.js
@@ -67,7 +67,7 @@ import * as spidTalk from './spidTalk';
  */
 
 const HAS_SESSION_CACHE_KEY = 'hasSession-cache';
-const globalWindow = window;
+const globalWindow = () => window; // eslint-disable-line require-jsdoc
 
 /**
  * Get type and value of something
@@ -95,7 +95,7 @@ export class Identity extends EventEmitter {
      * no logging will be done
      * @throws {SDKError} - If any of options are invalid
      */
-    constructor({ clientId, redirectUri, env = 'PRE', log, window = globalWindow }) {
+    constructor({ clientId, redirectUri, env = 'PRE', log, window = globalWindow() }) {
         super();
         assert(isNonEmptyString(clientId), 'clientId parameter is required');
         assert(isObject(window), 'The reference to window is missing');

--- a/src/monetization.js
+++ b/src/monetization.js
@@ -13,7 +13,7 @@ import Cache from './cache';
 import * as spidTalk from './spidTalk';
 
 const DEFAULT_CACHE_EXPIRES_IN = 30;
-const globalWindow = window;
+const globalWindow = () => window; // eslint-disable-line require-jsdoc
 
 /**
  * Provides features related to monetization
@@ -26,7 +26,7 @@ export class Monetization extends EventEmitter {
      * @param {string} [options.env=PRE] - Schibsted Account environment: `PRE`, `PRO` or `PRO_NO`
      * @throws {SDKError} - If any of options are invalid
      */
-    constructor({ clientId, redirectUri, env = 'PRE', window = globalWindow }) {
+    constructor({ clientId, redirectUri, env = 'PRE', window = globalWindow() }) {
         super();
         spidTalk.emulate(window);
         // validate options

--- a/src/payment.js
+++ b/src/payment.js
@@ -12,7 +12,7 @@ import * as popup from './popup';
 import RESTClient from './RESTClient';
 import * as spidTalk from './spidTalk';
 
-const globalWindow = window;
+const globalWindow = () => window; // eslint-disable-line require-jsdoc
 
 /**
  * Provides features related to payment
@@ -25,7 +25,7 @@ export class Payment {
      * @param {string} [options.env=PRE] - Schibsted Account environment: `PRE`, `PRO` or `PRO_NO`
      * @throws {SDKError} - If any of options are invalid
      */
-    constructor({ clientId, redirectUri, env = 'PRE', window = globalWindow }) {
+    constructor({ clientId, redirectUri, env = 'PRE', window = globalWindow() }) {
         spidTalk.emulate(window);
         assert(isNonEmptyString(clientId), 'clientId parameter is required');
 


### PR DESCRIPTION
Fixes #41 (I hope..)

This was an issue for people using server-side rendering, where simply
importing a file will break when there are references to window at the
root level of a file.