### PR TITLE
hassession: emit proper events and ensure caching works properly

### DIFF
--- a/__tests__/cache.js
+++ b/__tests__/cache.js
@@ -94,6 +94,15 @@ describe('cache', () => {
                     }, 10); // wait 10 ms, then check
                 });
             });
+            test('values should not expire if expiresIn is large', () => {
+                cache.set('foo', 'bar', 2592000000);
+                return new Promise((resolve) => {
+                    setTimeout(() => {
+                        expect(cache.get('foo')).toBe('bar');
+                        resolve();
+                    }, 10); // wait 10 ms, then check
+                });
+            });
             test('should be able to delete values', () => {
                 cache.set('foo', 'bar', 10000);
                 cache.delete('foo');

--- a/__tests__/identity.js
+++ b/__tests__/identity.js
@@ -260,6 +260,14 @@ describe('Identity', () => {
             // two calls per hasSession() invocation, since our mock is set up this way
             expect(fetch.mock.calls.length).toBe(2);
         });
+
+        test('should emit event both when "real" and "cached" values are used', async () => {
+            const spy = jest.fn();
+            identity.on('login', spy);
+            await identity.hasSession();
+            await identity.hasSession();
+            expect(spy).toHaveBeenCalledTimes(2);
+        });
     });
 
     describe('isLoggedIn', () => {

--- a/src/cache.js
+++ b/src/cache.js
@@ -63,6 +63,8 @@ class LiteralCache {
     }
 }
 
+const maxExpiresIn = Math.pow(2, 31) - 1;
+
 /**
  * Cache class that attempts WebStorage (session/local storage), and falls back to JS object literal
  * @private
@@ -113,6 +115,7 @@ export default class Cache {
         if (expiresIn <= 0) {
             return;
         }
+        expiresIn = Math.min(maxExpiresIn, expiresIn);
 
         try {
             const expiresOn = Math.floor(Date.now() + expiresIn);

--- a/src/identity.js
+++ b/src/identity.js
@@ -341,6 +341,7 @@ export class Identity extends EventEmitter {
             // Try to resolve from cache (it has a TTL)
             const cachedData = this.cache.get(HAS_SESSION_CACHE_KEY);
             if (cachedData) {
+                this._emitSessionEvent(this._session, cachedData);
                 return cachedData;
             }
         }


### PR DESCRIPTION
Fixes #40 

There were two things happening here:

1. The events were not being emitted when we used values from the cache 🤦‍♂️
1. The cache had a `setTimeout` that would remove cached items after an `expiresIn` amount of milliseconds (coming from the Schibsted account backend). When Safari is used, the backend sends 2592000000 (30 days), which exceeds the maximum value for `setTimeout` and in this case, it executes immediately.