### PR TITLE
Lax require-jsdoc eslint rule for arrow functions

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -22,7 +22,7 @@ rules:
           FunctionDeclaration: true
           ClassDeclaration: true
           MethodDefinition: true
-          ArrowFunctionExpression: true
+          ArrowFunctionExpression: false
           FunctionExpression: true
     valid-jsdoc:
       - warn

--- a/src/RESTClient.js
+++ b/src/RESTClient.js
@@ -45,7 +45,6 @@ function encode(str) {
     return encodeURIComponent(str).replace(/[!'()~]|%20|%00/g, match => replace[match]);
 }
 
-// eslint-disable-next-line require-jsdoc
 const globalFetch = () => window.fetch && window.fetch.bind(window);
 
 /**

--- a/src/identity.js
+++ b/src/identity.js
@@ -67,7 +67,7 @@ import * as spidTalk from './spidTalk';
  */
 
 const HAS_SESSION_CACHE_KEY = 'hasSession-cache';
-const globalWindow = () => window; // eslint-disable-line require-jsdoc
+const globalWindow = () => window;
 
 /**
  * Get type and value of something

--- a/src/monetization.js
+++ b/src/monetization.js
@@ -13,7 +13,7 @@ import Cache from './cache';
 import * as spidTalk from './spidTalk';
 
 const DEFAULT_CACHE_EXPIRES_IN = 30;
-const globalWindow = () => window; // eslint-disable-line require-jsdoc
+const globalWindow = () => window;
 
 /**
  * Provides features related to monetization

--- a/src/payment.js
+++ b/src/payment.js
@@ -12,7 +12,7 @@ import * as popup from './popup';
 import RESTClient from './RESTClient';
 import * as spidTalk from './spidTalk';
 
-const globalWindow = () => window; // eslint-disable-line require-jsdoc
+const globalWindow = () => window;
 
 /**
  * Provides features related to payment

--- a/src/validate.js
+++ b/src/validate.js
@@ -106,7 +106,7 @@ export function isFunction(value) {
  * @return {boolean}
  */
 export function isStrIn(value, possibilities, caseSensitive = false) {
-    const _isSameStrCaseInsensitive = str => // eslint-disable-line require-jsdoc
+    const _isSameStrCaseInsensitive = str =>
         isStr(str) && value.toUpperCase() === str.toUpperCase();
     if (!(isStr(value) && Array.isArray(possibilities))) {
         return false;


### PR DESCRIPTION
We want docs for exported functions, sure, but it’s overkill to demand
it for small helpers. When the source gets scattered with eslint-disable
stuff, it’s a good sign that rules should be changed I think.