### PR TITLE
es5: Ensure regeneratorRuntime is available

### DIFF
--- a/src/es5/global.js
+++ b/src/es5/global.js
@@ -8,11 +8,6 @@
 
 'use strict';
 
-const regeneratorRuntime = require('regenerator-runtime');
-const { Identity } = require('../identity');
-const { Monetization } = require('../monetization');
-const { Payment } = require('../payment');
+const { Identity, Monetization, Payment } = require('./index');
 
-module.exports = { Identity, Monetization, Payment };
-
-Object.assign(window, { Identity, Monetization, Payment, regeneratorRuntime });
+Object.assign(window, { Identity, Monetization, Payment });


### PR DESCRIPTION
This file was not working well, since it didn’t assign
window.regeneratorRuntime before attempting to load Identity,
Monetization and Payment. D’oh! This commit simplifies how it works, by
reusing what happens in index.js.