### PR TITLE
ignore null params when constructing uri

### DIFF
--- a/__tests__/payment.js
+++ b/__tests__/payment.js
@@ -180,12 +180,17 @@ describe('Payment', () => {
 
         test('should work with implicit redirectUri', () => {
             const url = payment.purchaseCampaignFlowUrl();
-            expect(url).toMatch(/checkout\?client_id=a&redirect_uri=http%3A%2F%2Fredirect.foo&response_type=code&flow=payment&campaign_id=null&product_id=null&voucher_code=null/);
+            expect(url).toMatch(/checkout\?client_id=a&redirect_uri=http%3A%2F%2Fredirect.foo&response_type=code&flow=payment/);
         });
 
         test('should fail without redirectUri', () => {
             payment = new Payment({ clientId: 'a', window });
             expect(() => payment.purchaseCampaignFlowUrl('abc')).toThrowError(/redirectUri is invalid/);
+        });
+
+        test('should build uri with campaign_id and product_id', () => {
+            const url = payment.purchaseCampaignFlowUrl(12, 20032);
+            expect(url).toMatch(/checkout\?client_id=a&redirect_uri=http%3A%2F%2Fredirect.foo&response_type=code&flow=payment&campaign_id=12&product_id=20032/);
         });
     });
 });

--- a/__tests__/payment.js
+++ b/__tests__/payment.js
@@ -107,6 +107,10 @@ describe('Payment', () => {
             payment = new Payment({ clientId: 'a', window });
             expect(() => payment.purchasePaylinkUrl('abc')).toThrowError(/redirectUri is invalid/);
         });
+
+        test('should fail without paylinkId', () => {
+            expect(() => payment.purchasePaylinkUrl()).toThrowError(/paylinkId is required/);
+        });
     });
 
     describe('purchaseHistoryUrl', () => {
@@ -167,6 +171,10 @@ describe('Payment', () => {
             payment = new Payment({ clientId: 'a', window });
             expect(() => payment.purchaseProductFlowUrl('abc')).toThrowError(/redirectUri is invalid/);
         });
+
+        test('should fail without product id', () => {
+            expect(() => payment.purchaseProductFlowUrl()).toThrowError(/productId is required/);
+        });
     });
 
     describe('purchaseCampaignFlowUrl', () => {
@@ -179,8 +187,8 @@ describe('Payment', () => {
         });
 
         test('should work with implicit redirectUri', () => {
-            const url = payment.purchaseCampaignFlowUrl();
-            expect(url).toMatch(/checkout\?client_id=a&redirect_uri=http%3A%2F%2Fredirect.foo&response_type=code&flow=payment/);
+            const url = payment.purchaseCampaignFlowUrl('12', '20032');
+            expect(url).toMatch(/checkout\?client_id=a&redirect_uri=http%3A%2F%2Fredirect.foo&response_type=code&flow=payment&campaign_id=12&product_id=20032/);
         });
 
         test('should fail without redirectUri', () => {
@@ -189,8 +197,12 @@ describe('Payment', () => {
         });
 
         test('should build uri with campaign_id and product_id', () => {
-            const url = payment.purchaseCampaignFlowUrl(12, 20032);
+            const url = payment.purchaseCampaignFlowUrl('12', '20032');
             expect(url).toMatch(/checkout\?client_id=a&redirect_uri=http%3A%2F%2Fredirect.foo&response_type=code&flow=payment&campaign_id=12&product_id=20032/);
+        });
+
+        test('should fail without campaign id', () => {
+            expect(() => payment.purchaseCampaignFlowUrl()).toThrowError(/campaignId is required/);
         });
     });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -2326,6 +2326,10 @@
         "randombytes": "2.0.6"
       }
     },
+    "docdash": {
+      "version": "git+https://github.com/torarvid/docdash.git#ebcf36e4bde163fc961b391c2b770042a18fb511",
+      "dev": true
+    },
     "doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",

--- a/src/RESTClient.js
+++ b/src/RESTClient.js
@@ -180,7 +180,7 @@ export class RESTClient {
      */
     static search(query, useDefaultParams, defaultParams) {
         const params = useDefaultParams ? cloneDefined(defaultParams, query) : cloneDefined(query);
-        return Object.keys(params).map(p => params[p] !== null ? `${encode(p)}=${encode(params[p])}` : '').join('&');
+        return Object.keys(params).map(p => `${encode(p)}=${encode(params[p])}`).join('&');
     }
 }
 

--- a/src/RESTClient.js
+++ b/src/RESTClient.js
@@ -180,7 +180,7 @@ export class RESTClient {
      */
     static search(query, useDefaultParams, defaultParams) {
         const params = useDefaultParams ? cloneDefined(defaultParams, query) : cloneDefined(query);
-        return Object.keys(params).map(p => `${encode(p)}=${encode(params[p])}`).join('&');
+        return Object.keys(params).map(p => params[p] !== null ? `${encode(p)}=${encode(params[p])}` : '').join('&');
     }
 }
 

--- a/src/payment.js
+++ b/src/payment.js
@@ -132,6 +132,7 @@ export class Payment {
      */
     purchasePaylinkUrl(paylinkId, redirectUri = this.redirectUri) {
         assert(isUrl(redirectUri), `purchasePaylinkUrl(): redirectUri is invalid`);
+        assert(isNonEmptyString(paylinkId), `purchasePaylinkUrl(): paylinkId is required`);
         return this._bff.makeUrl('payment/purchase', {
             paylink: paylinkId,
             redirect_uri: redirectUri
@@ -147,6 +148,7 @@ export class Payment {
      */
     purchaseProductFlowUrl(productId, redirectUri = this.redirectUri) {
         assert(isUrl(redirectUri), `purchaseProductUrl(): redirectUri is invalid`);
+        assert(isNonEmptyString(productId), `purchaseProductFlowUrl(): productId is required`);
         return this._bff.makeUrl('flow/checkout', {
             response_type: 'code',
             flow: 'payment',
@@ -165,7 +167,9 @@ export class Payment {
      * @return {string} - The url to the products review page
      */
     purchaseCampaignFlowUrl(campaignId, productId, voucherCode, redirectUri = this.redirectUri) {
-        assert(isUrl(redirectUri), `purchaseProductUrl(): redirectUri is invalid`);
+        assert(isUrl(redirectUri), `purchaseCampaignFlowUrl(): redirectUri is invalid`);
+        assert(isNonEmptyString(campaignId), `purchaseCampaignFlowUrl(): campaignId is required`);
+        assert(isNonEmptyString(productId), `purchaseCampaignFlowUrl(): productId is required`);
         return this._bff.makeUrl('flow/checkout', {
             response_type: 'code',
             flow: 'payment',

--- a/src/payment.js
+++ b/src/payment.js
@@ -164,7 +164,7 @@ export class Payment {
      * @param {string} [redirectUri=this.redirectUri]
      * @return {string} - The url to the products review page
      */
-    purchaseCampaignFlowUrl(campaignId = null, productId = null, voucherCode = null, redirectUri = this.redirectUri) {
+    purchaseCampaignFlowUrl(campaignId, productId, voucherCode, redirectUri = this.redirectUri) {
         assert(isUrl(redirectUri), `purchaseProductUrl(): redirectUri is invalid`);
         return this._bff.makeUrl('flow/checkout', {
             response_type: 'code',

--- a/src/payment.js
+++ b/src/payment.js
@@ -160,7 +160,7 @@ export class Payment {
      * @todo Check working-ness for BFF + SPiD
      * @param {string} campaignId
      * @param {string} productId
-     * @param {string} voucherCode
+     * @param {string} [voucherCode]
      * @param {string} [redirectUri=this.redirectUri]
      * @return {string} - The url to the products review page
      */


### PR DESCRIPTION
for now building purchase flow uri ends with params filled with null values like `voucher_code=null`
from now on default null values should be ingored