### PR TITLE
Change the logout function to do full-page redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ you read this document in full. But ok, let's present some highlighted differenc
    that you need set, you will have to set yourself
 * All functions that used to take callback functions in the 2.x version of the SDK don't do that
    anymore. The new SDK instead uses promises where it makes sense (often written as `async`
-   functions). For example `Identity.logout()` returns a promise. So, for instance if you used to do
+   functions). For example `Identity.getUser()` returns a promise. So, for instance if you used to do
    this in v2.x:
    ```javascript
    identity.hasSession((err, data) => {

--- a/src/identity.js
+++ b/src/identity.js
@@ -597,39 +597,15 @@ export class Identity extends EventEmitter {
 
     /**
      * @summary Logs the user out from the Identity platform
-     * @description **Note**: Your site origin should be listed as a redirect_uri in selfservice for
-     * this to work. On the Schibsted account side, we check CORS headers against the list of
-     * redirect_uris. For most sites, this will work already, since this matching is only done on
-     * the origin part of the uri, and most sites already have that in their redirect_uri list. So
-     * if you have a redirect_uri `https://mysite.news/article`, then this will work when coming
-     * from any `https://mysite.news` location. Note however, that the protocol matters, so it will
-     * not work for `http://mysite.news` (only `https`).
+     * @param {string} redirectUri - Where to redirect the browser after logging out of Schibsted
+     * account
      * @return {void}
      */
-    async logout() {
-        // At the moment we have two endpoints that can have user session: SPiD and BFF
-        // if one of them returns success, we assume that the login was successful
-        // but if both fail, then we haven't really logged the user out.
-        /**
-         * A little utility function that returns a boolean based on if a promise has failed or
-         * succeeded.
-         * @param {Promise} p
-         * @return {Promise}
-         */
-        const booleanize = p => p.then(() => true, () => false);
-        const [spidLoggedOut, bffLoggedOut] = await Promise.all([
-            booleanize(this._spid.get('ajax/logout.js')),
-            booleanize(this._bffService.get('api/identity/logout')),
-        ]);
-        if (spidLoggedOut || bffLoggedOut) {
-            this.cache.delete(HAS_SESSION_CACHE_KEY);
-            this._maybeClearVarnishCookie();
-            this.emit('logout');
-        } else {
-            const err = new SDKError('Could not log out from any endpoint');
-            this.emit('error', err);
-            throw err;
-        }
+    logout(redirectUri = this.redirectUri) {
+        this.cache.delete(HAS_SESSION_CACHE_KEY);
+        this._maybeClearVarnishCookie();
+        this.emit('logout');
+        this.window.location.href = this.logoutUrl(redirectUri);
     }
 
     /**


### PR DESCRIPTION
We can’t rely on XHRs working after Safari 12. VG showed that it doesn’t
work correctly on the SPiD side, although I don’t fully understand why.
What we observe is:

1) Log in from VG
2) Log out from VG (observe that the Network tab has requests going to
   /ajax/logout.js and /authn/identity/logout — both returning 200. This
   makes VG of course show you as logged out
3) Log in again. Observe that you are (wrongly) automatically logged in
   with no need for authentication

Since we want to move away from XHRs relying on 3rd party cookies
anyway, this commit changes the way it works by doing a full-page
redirect (after cleaning up cache/varnish cookie) instead. Since there
are no requests being sent in logout() anymore, I removed the async
modifier, even though this is a breaking change.