### PR TITLE
cache: Handle when just accessing webStorage throws

### DIFF
--- a/__tests__/cache.js
+++ b/__tests__/cache.js
@@ -31,21 +31,32 @@ describe('cache', () => {
             expect(cache.type).toBe('ObjectLiteralStorage');
         });
         test('can force a cache with session storage', () => {
-            const cache = new Cache(webStorageMock());
+            const cache = new Cache(webStorageMock);
             expect(cache.type).toBe('WebStorage');
         });
         test('Falls back to object literal storage if supplied storage throws', () => {
-            const cache = new Cache(throwingStorageMock);
+            const cache = new Cache(() => throwingStorageMock);
             expect(cache.type).toBe('ObjectLiteralStorage');
             expect(throwingStorageMock.spy).toHaveBeenCalledTimes(1);
             expect(throwingStorageMock.spy.mock.calls[0][1]).toBe('TEST-VALUE');
+        });
+        test('Falls back to object literal storage if fetching localStorage throws exception', () => {
+            const spy = jest.fn().mockImplementation(() => {
+                throw Error('Private mode, yo');
+            });
+            const throwingWindowInstance = {
+                get localStorage() { return spy(); }
+            };
+            const cache = new Cache(() => throwingWindowInstance.localStorage);
+            expect(cache.type).toBe('ObjectLiteralStorage');
+            expect(spy).toHaveBeenCalledTimes(1);
         });
     });
     describe('web storage', () => {
         describe('get/set/clear', () => {
             let cache;
             beforeEach(() => {
-                cache = new Cache(webStorageMock());
+                cache = new Cache(webStorageMock);
             });
             test('can read/write values', () => {
                 cache.set('foo', 'bar', 1000);

--- a/src/cache.js
+++ b/src/cache.js
@@ -8,16 +8,17 @@ import SDKError from './SDKError';
 
 /**
  * Check whether we are able to use web storage
- * @param {Storage} store - A reference to either `sessionStorage` or `localStorage` from a `Window`
- * object
+ * @param {Storage} storeProvider - A function to return a WebStorage instance (either
+ * `sessionStorage` or `localStorage` from a `Window` object)
  * @private
  * @returns {boolean}
  */
-function webStorageWorks(store) {
-    if (!store) {
+function webStorageWorks(storeProvider) {
+    if (!storeProvider) {
         return false;
     }
     try {
+        const store = storeProvider();
         const randomKey = 'x-x-x-x'.replace(/x/g, () => Math.random());
         const testValue = 'TEST-VALUE';
         store.setItem(randomKey, testValue);
@@ -71,13 +72,13 @@ const maxExpiresIn = Math.pow(2, 31) - 1;
  */
 export default class Cache {
     /**
-     * @param {Storage} [store] - A reference to either `sessionStorage` or `localStorage` from a
-     * `Window` object
+     * @param {Storage} [storeProvider] - A function to return a WebStorage instance (either
+     * `sessionStorage` or `localStorage` from a `Window` object)
      * @throws {SDKError} - If sessionStorage or localStorage are not accessible
      */
-    constructor(store) {
-        if (webStorageWorks(store)) {
-            this.cache = new WebStorageCache(store);
+    constructor(storeProvider) {
+        if (webStorageWorks(storeProvider)) {
+            this.cache = new WebStorageCache(storeProvider());
             this.type = 'WebStorage';
         } else {
             this.cache = new LiteralCache();

--- a/src/identity.js
+++ b/src/identity.js
@@ -101,7 +101,7 @@ export class Identity extends EventEmitter {
         this._sessionInitiatedSent = false;
         this.window = window;
         this.clientId = clientId;
-        this.cache = new Cache(this.window && this.window.localStorage);
+        this.cache = new Cache(() => this.window && this.window.localStorage);
         this.redirectUri = redirectUri;
         this.env = env;
         this.log = log;

--- a/src/monetization.js
+++ b/src/monetization.js
@@ -32,7 +32,7 @@ export class Monetization extends EventEmitter {
         // validate options
         assert(isNonEmptyString(clientId), 'clientId parameter is required');
 
-        this.cache = new Cache(window && window.sessionStorage);
+        this.cache = new Cache(() => window && window.sessionStorage);
         this.clientId = clientId;
         this.redirectUri = redirectUri;
         this._setSpidServerUrl(env);


### PR DESCRIPTION
On for instance Safari 10 in Private mode, the simple act of accessing
window.localStorage will throw an exception. This commit adds a test for
this case, as well as change the constructor of the (internal) Cache
class to take a provider function instead of an actual storage object.
This is just to keep the complexity of dealing with that possible
exception inside the Cache class (in the ‘webStorageWorks’ helper
function).

Thanks to @olekenneth for making us aware of this issue