### PR TITLE
Add locale param to login

### DIFF
--- a/__tests__/identity.js
+++ b/__tests__/identity.js
@@ -55,7 +55,7 @@ describe('Identity', () => {
             const identity = new Identity({ clientId: 'foo', redirectUri: 'http://foo.com', window });
             identity.login({ state: 'foo' });
             expect(window).toHaveProperty('location.href',
-                'https://identity-pre.schibsted.com/oauth/authorize?client_id=foo&redirect_uri=http%3A%2F%2Ffoo.com&response_type=code&new-flow=true&scope=openid&state=foo&login_hint=&tag=&teaser=&max_age=');
+                'https://identity-pre.schibsted.com/oauth/authorize?client_id=foo&redirect_uri=http%3A%2F%2Ffoo.com&response_type=code&new-flow=true&scope=openid&state=foo');
         });
         test('Should open popup if "preferPopup" is true', () => {
             const window = { screen: {}, open: () => ({ fakePopup: 'yup' }) };
@@ -68,7 +68,7 @@ describe('Identity', () => {
             const identity = new Identity({ clientId: 'foo', redirectUri: 'http://foo.com', window });
             identity.login({ state: 'foo', preferPopup: true });
             expect(window).toHaveProperty('location.href',
-                'https://identity-pre.schibsted.com/oauth/authorize?client_id=foo&redirect_uri=http%3A%2F%2Ffoo.com&response_type=code&new-flow=true&scope=openid&state=foo&login_hint=&tag=&teaser=&max_age=');
+                'https://identity-pre.schibsted.com/oauth/authorize?client_id=foo&redirect_uri=http%3A%2F%2Ffoo.com&response_type=code&new-flow=true&scope=openid&state=foo');
         });
         test('Should close previous popup if it exists (and is open)', () => {
             const window = { screen: {}, open: () => ({ fakePopup: 'yup' }) };
@@ -141,8 +141,9 @@ describe('Identity', () => {
                 newFlow: false,
                 loginHint: 'dev@spid.no',
                 tag: 'sample-tag',
-                teaser: 'sample-teaser-slug'
-            }), 'https://payment.schibsted.no/flow/login?client_id=foo&state=dummy-state&scope=openid&response_type=code&redirect_uri=http%3A%2F%2Fexample.com&email=dev@spid.no&tag=sample-tag&teaser=sample-teaser-slug');
+                teaser: 'sample-teaser-slug',
+                locale: 'en_US'
+            }), 'https://payment.schibsted.no/flow/login?client_id=foo&state=dummy-state&scope=openid&response_type=code&redirect_uri=http%3A%2F%2Fexample.com&email=dev@spid.no&tag=sample-tag&teaser=sample-teaser-slug&locale=en_US');
         });
 
         test('returns the expected endpoint for new flows', () => {
@@ -158,8 +159,9 @@ describe('Identity', () => {
                 loginHint: 'dev@spid.no',
                 tag: 'sample-tag',
                 teaser: 'sample-teaser-slug',
-                maxAge: 0
-            }), 'https://login.schibsted.com/oauth/authorize?new-flow=true&redirect_uri=http%3A%2F%2Fexample.com&client_id=foo&state=dummy-state&response_type=code&scope=openid&login_hint=dev@spid.no&max_age=0&tag=sample-tag&teaser=sample-teaser-slug');
+                maxAge: 0,
+                locale: 'en_US'
+            }), 'https://login.schibsted.com/oauth/authorize?new-flow=true&redirect_uri=http%3A%2F%2Fexample.com&client_id=foo&state=dummy-state&response_type=code&scope=openid&login_hint=dev@spid.no&max_age=0&tag=sample-tag&teaser=sample-teaser-slug&locale=en_US');
         });
 
         test('returns the expected endpoint for new flows with default params', () => {
@@ -171,7 +173,7 @@ describe('Identity', () => {
             });
             compareUrls(identity.loginUrl({
                 state: 'dummy-state',
-            }), 'https://login.schibsted.com/oauth/authorize?new-flow=true&redirect_uri=http%3A%2F%2Fexample.com&client_id=foo&state=dummy-state&response_type=code&scope=openid&login_hint=&max_age=&tag=&teaser=');
+            }), 'https://login.schibsted.com/oauth/authorize?new-flow=true&redirect_uri=http%3A%2F%2Fexample.com&client_id=foo&state=dummy-state&response_type=code&scope=openid');
         });
     });
 
@@ -227,7 +229,7 @@ describe('Identity', () => {
                 undefined,
                 undefined,
                 undefined,
-            ), 'https://login.schibsted.com/oauth/authorize?new-flow=true&redirect_uri=http%3A%2F%2Fexample.com&client_id=foo&state=dummy-state&response_type=code&scope=openid&login_hint=&max_age=&tag=&teaser=');
+            ), 'https://login.schibsted.com/oauth/authorize?new-flow=true&redirect_uri=http%3A%2F%2Fexample.com&client_id=foo&state=dummy-state&response_type=code&scope=openid');
         });
     });
 

--- a/src/RESTClient.js
+++ b/src/RESTClient.js
@@ -180,7 +180,7 @@ export class RESTClient {
      */
     static search(query, useDefaultParams, defaultParams) {
         const params = useDefaultParams ? cloneDefined(defaultParams, query) : cloneDefined(query);
-        return Object.keys(params).map(p => `${encode(p)}=${encode(params[p])}`).join('&');
+        return Object.keys(params).filter(p => params[p]!=='').map(p => `${encode(p)}=${encode(params[p])}`).join('&');
     }
 }
 

--- a/src/identity.js
+++ b/src/identity.js
@@ -563,6 +563,8 @@ export class Identity extends EventEmitter {
      * the last time the End-User was actively authenticated. If last authentication time is more
      * than maxAge seconds in the past, re-authentication will be required. See the OpenID Connect
      * spec section 3.1.2.1 for more information
+     * @param {string} [options.locale=''] - Optional parameter to overwrite client locale setting.
+     * New flows supports nb_NO, fi_FI, sv_SE, en_US
      * @return {Window|null} - Reference to popup window if created (or `null` otherwise)
      */
     login({
@@ -575,12 +577,13 @@ export class Identity extends EventEmitter {
         loginHint = '',
         tag = '',
         teaser = '',
-        maxAge = ''
+        maxAge = '',
+        locale = ''
     }) {
         this._closePopup();
         this.cache.delete(HAS_SESSION_CACHE_KEY);
         const url = this.loginUrl({ state, acrValues, scope, redirectUri, newFlow, loginHint, tag,
-            teaser, maxAge });
+            teaser, maxAge, locale });
 
         this.showItpModalUponReturning();
 
@@ -630,6 +633,8 @@ export class Identity extends EventEmitter {
      * the last time the End-User was actively authenticated. If last authentication time is more
      * than maxAge seconds in the past, re-authentication will be required. See the OpenID Connect
      * spec section 3.1.2.1 for more information
+     * @param {string} [options.locale=''] - Optional parameter to overwrite client locale setting.
+     * New flows supports nb_NO, fi_FI, sv_SE, en_US
      * @return {string} - The url
      */
     loginUrl({
@@ -641,7 +646,8 @@ export class Identity extends EventEmitter {
         loginHint = '',
         tag = '',
         teaser = '',
-        maxAge = ''
+        maxAge = '',
+        locale = ''
     }) {
         if (typeof arguments[0] !== 'object') {
             // backward compatibility
@@ -674,7 +680,8 @@ export class Identity extends EventEmitter {
                 login_hint: loginHint,
                 tag,
                 teaser,
-                max_age: maxAge
+                max_age: maxAge,
+                locale
             });
         } else {
             // acrValues do not work with the old flows
@@ -685,7 +692,8 @@ export class Identity extends EventEmitter {
                 state,
                 email: loginHint,
                 tag,
-                teaser
+                teaser,
+                locale
             });
         }
     }


### PR DESCRIPTION
The most important change is https://github.com/schibsted/account-sdk-browser/compare/add-locale-param-to-login?expand=1#diff-b8139375bef5ea9da4706270fef9c716R183 . I believe that it shouldn't have big influence since it will skip only empty string query params.