### PR TITLE
silently catch errors from Object.assign in SDKError

### DIFF
--- a/src/SDKError.js
+++ b/src/SDKError.js
@@ -30,8 +30,12 @@ export default class SDKError extends Error {
         super(message);
         this.name = 'SDKError';
         if (typeof errorObject === 'object') {
-            // At this point it doesn't matter if errorObject === null
-            Object.assign(this, errorObject);
+            try {
+                // At this point it doesn't matter if errorObject === null
+                Object.assign(this, errorObject);
+            } catch(err) {
+                // silent
+            }
         }
     }
 


### PR DESCRIPTION
silently catch errors from Object.assign in SDKError

fixes https://github.com/schibsted/account-sdk-browser/issues/101