### PR TITLE
fix(src): reject in hasSession

### DIFF
--- a/src/identity.js
+++ b/src/identity.js
@@ -452,7 +452,9 @@ export class Identity extends EventEmitter {
                         // session-cookie but no session is found (return code will be 404), then we
                         // *should* throw an exception and *not* fall through to spid-hassession
                         if (err.code !== 400) {
-                            throw err;
+                            this.emit('error', err);
+                            reject(new SDKError('HasSession failed', err));
+                            return;
                         }
                         data = null;
                     }

--- a/src/identity.js
+++ b/src/identity.js
@@ -418,7 +418,7 @@ export class Identity extends EventEmitter {
             const postProcess = (sessionData) => {
                 if (sessionData.error) {
                     this.emit('error', sessionData.error);
-                    reject(new SDKError('HasSession failed', sessionData.error));
+                    return reject(new SDKError('HasSession failed', sessionData.error));
                 }
                 this._maybeSetVarnishCookie(sessionData);
                 this._emitSessionEvent(this._session, sessionData);
@@ -426,8 +426,7 @@ export class Identity extends EventEmitter {
 
             if (typeof autologin !== 'boolean') {
                 const [type, value] = inspect(autologin);
-                reject(new SDKError(`Parameter 'autologin' must be boolean, was: "${type}:${value}"`));
-                return;
+                return reject(new SDKError(`Parameter 'autologin' must be boolean, was: "${type}:${value}"`));
             }
 
             try {
@@ -436,8 +435,7 @@ export class Identity extends EventEmitter {
                     const cachedData = this.cache.get(HAS_SESSION_CACHE_KEY);
                     if (cachedData) {
                         postProcess(cachedData);
-                        resolve(cachedData);
-                        return;
+                        return resolve(cachedData);
                     }
                 }
 
@@ -453,8 +451,7 @@ export class Identity extends EventEmitter {
                         // *should* throw an exception and *not* fall through to spid-hassession
                         if (err.code !== 400) {
                             this.emit('error', err);
-                            reject(new SDKError('HasSession failed', err));
-                            return;
+                            return reject(new SDKError('HasSession failed', err));
                         }
                         data = null;
                     }

--- a/src/identity.js
+++ b/src/identity.js
@@ -417,7 +417,8 @@ export class Identity extends EventEmitter {
         const promiseFn = async (resolve, reject) => {
             const postProcess = (sessionData) => {
                 if (sessionData.error) {
-                    throw new SDKError('HasSession endpoint returned an error', sessionData.error);
+                    this.emit('error', sessionData.error);
+                    reject(new SDKError('HasSession failed', sessionData.error));
                 }
                 this._maybeSetVarnishCookie(sessionData);
                 this._emitSessionEvent(this._session, sessionData);


### PR DESCRIPTION
## What
We have struggled with bad performance in terms of prolonged script evaluation in Internet Explorer 11 and tracked it down to https://github.com/schibsted/account-sdk-browser/blob/master/src/identity.js#L485 being the issue.

Instead of throwing an error in `postProcess`, we first emit an error event (not sure if needed), like it does in the catch block, then reject.

This resulted in script evaluation going from 20-30s to 1.5-3s in IE11.