### PR TITLE
Add Identity function to get user context data.

### DIFF
--- a/__tests__/identity.js
+++ b/__tests__/identity.js
@@ -556,7 +556,7 @@ describe('Identity', () => {
         });
 
         test('should work when we get a result from session-service', async () => {
-            const expectedData = { email: 'test@example.com' }
+            const expectedData = { identifier: 'test@example.com' }
             identity._globalSessionService.fetch = jest.fn(() => ({ ok: true, json: () => expectedData }));
             const userData = await identity.getUserContextData();
             expect(userData).toMatchObject(expectedData);

--- a/__tests__/identity.js
+++ b/__tests__/identity.js
@@ -548,6 +548,27 @@ describe('Identity', () => {
         });
     });
 
+    describe('getUserContextData', () => {
+        let identity;
+
+        beforeEach(() => {
+            identity = new Identity({ clientId: 'foo', redirectUri: 'http://example.com' });
+        });
+
+        test('should work when we get a result from session-service', async () => {
+            const expectedData = { email: 'test@example.com' }
+            identity._globalSessionService.fetch = jest.fn(() => ({ ok: true, json: () => expectedData }));
+            const userData = await identity.getUserContextData();
+            expect(userData).toMatchObject(expectedData);
+        });
+
+        test('should return null on failure from session-service', async () => {
+            identity._globalSessionService.fetch = jest.fn(() => ({ ok: false }));
+            const userData = await identity.getUserContextData();
+            expect(userData).toBeNull();
+        });
+    });
+
     describe('_emitSessionEvent', () => {
         const fetch = require('fetch-jsonp');
         let identity;

--- a/src/config.js
+++ b/src/config.js
@@ -40,6 +40,12 @@
  * @prop {string} ENDPOINTS.BFF.PRE - Staging environment
  * @prop {string} ENDPOINTS.BFF.PRO - Production environment Sweden
  * @prop {string} ENDPOINTS.BFF.PRO_NO - Production environment Norway
+ * @prop {object} ENDPOINTS.SESSION_SERVICE - Endpoints to check global user session data
+ * @prop {string} ENDPOINTS.SESSION_SERVICE.LOCAL - Local endpoint (for Identity team)
+ * @prop {string} ENDPOINTS.SESSION_SERVICE.DEV - Dev environment (for Identity team)
+ * @prop {string} ENDPOINTS.SESSION_SERVICE.PRE - Staging environment
+ * @prop {string} ENDPOINTS.SESSION_SERVICE.PRO - Production environment Sweden
+ * @prop {string} ENDPOINTS.SESSION_SERVICE.PRO_NO - Production environment Norway
  * @prop {object} JSONP
  * @prop {Number} JSONP.TIMEOUT=7000 - Timeout in milliseconds
  */
@@ -65,6 +71,13 @@ const config = {
             PRE: 'https://identity-pre.schibsted.com/authn/',
             PRO: 'https://login.schibsted.com/authn/',
             PRO_NO: 'https://payment.schibsted.no/authn/',
+        },
+        SESSION_SERVICE: {
+            LOCAL: 'http://session-service.id.localhost',
+            DEV: 'https://session-service.identity-dev.schibsted.com',
+            PRE: 'https://session-service.identity-pre.schibsted.com',
+            PRO: 'https://session-service.login.schibsted.com',
+            PRO_NO: 'https://session-service.payment.schibsted.no',
         },
     },
     JSONP: { TIMEOUT: 7000 }, // ms

--- a/src/identity.js
+++ b/src/identity.js
@@ -64,7 +64,7 @@ import * as spidTalk from './spidTalk';
 
 /**
  * @typedef {object} Identity#PublicUserData
- * @property {string} email
+ * @property {string} identifier
  */
 
 const HAS_SESSION_CACHE_KEY = 'hasSession-cache';

--- a/src/identity.js
+++ b/src/identity.js
@@ -62,6 +62,11 @@ import * as spidTalk from './spidTalk';
  * @property {number} response.serverTime - Server time in seconds since the Unix Epoch. Example: 1506287788
  */
 
+/**
+ * @typedef {object} Identity#PublicUserData
+ * @property {string} email
+ */
+
 const HAS_SESSION_CACHE_KEY = 'hasSession-cache';
 const LOGIN_IN_PROGRESS_KEY = 'loginInProgress-cache';
 const globalWindow = () => window;
@@ -127,6 +132,7 @@ export class Identity extends EventEmitter {
         this._setBffServerUrl(env);
         this._setOauthServerUrl(env);
         this._setHasSessionServerUrl(env);
+        this._setGlobalSessionServiceUrl(env);
     }
 
     /**
@@ -160,9 +166,9 @@ export class Identity extends EventEmitter {
     }
 
     /**
-     * Set BFF server URL - real URL or 'PRE' style key
+     * Set BFF server URL
      * @private
-     * @param {string} url
+     * @param {string} url  - real URL or 'PRE' style key
      * @returns {void}
      */
     _setBffServerUrl(url) {
@@ -175,7 +181,7 @@ export class Identity extends EventEmitter {
     }
 
     /**
-     * Set session-service domain
+     * Set site-specific session-service domain
      * @private
      * @param {string} domain - real URL — (**not** 'PRE' style env key)
      * @returns {void}
@@ -187,6 +193,22 @@ export class Identity extends EventEmitter {
             serverUrl: domain,
             log: this.log,
             defaultParams: { client_sdrn, redirect_uri: this.redirectUri },
+        });
+    }
+
+    /**
+     * Set global session-service server URL
+     * @private
+     * @param {string} url - real URL or 'PRE' style key
+     * @returns {void}
+     */
+    _setGlobalSessionServiceUrl(url) {
+        assert(isStr(url), `url parameter is invalid: ${url}`);
+        const client_sdrn = `sdrn:${NAMESPACE[this.env]}:client:${this.clientId}`;
+        this._globalSessionService = new RESTClient({
+            serverUrl: urlMapper(url, ENDPOINTS.SESSION_SERVICE),
+            log: this.log,
+            defaultParams: { client_sdrn },
         });
     }
 
@@ -585,6 +607,23 @@ export class Identity extends EventEmitter {
             return user.uuid;
         }
         throw new SDKError('The user is not connected to this merchant');
+    }
+
+    /**
+     * @summary Get basic information about any user currently logged-in to their Schibsted account
+     * in this browser. Can be used to provide context in a continue-as prompt.
+     * @description This function relies on the global Schibsted account user session cookie, which
+     * is a third-party cookie and hence might be blocked by the browser (for example due to ITP in
+     * Safari). So there's no guarantee any data is returned, even though a user is logged-in in
+     * the current browser.
+     * @return {Identity#PublicUserData|null}
+     */
+    async getUserContextData() {
+        try {
+            return await this._globalSessionService.get('/user-context');
+        } catch (_) {
+            return null;
+        }
     }
 
     /**


### PR DESCRIPTION
To enable the brand sites to contexutalise continue-as/simplified-login
prompts.

~*Note:* This depends on a new endpoint in session-service (not yet deployed), so don't merge yet. 🙂~