### PR TITLE
fix: remove Promise constructor in `hasSession`

### DIFF
--- a/__tests__/identity.js
+++ b/__tests__/identity.js
@@ -408,6 +408,21 @@ describe('Identity', () => {
             expect(fetch.mock.calls[0][0]).toMatch(/^http:\/\/id.e.com\//);
         });
 
+        test('should fail `hasSession` if session cookie is present but no session is found', async () => {
+            const options = { clientId: 'foo', redirectUri: 'http://e.com', sessionDomain: 'http://id.e.com' };
+            const client_sdrn = `sdrn:schibsted:client:${options.clientId}`;
+            identity = new Identity(options);
+            identity._sessionService = new RESTClient({
+                serverUrl: options.sessionDomain,
+                fetch,
+                defaultParams: { client_sdrn, redirect_uri: options.redirectUri },
+            });
+            fetch.mockImplementationOnce(async () => ({ ok: false, status: 404, statusText: 'No session found' }));
+            await expect(identity.hasSession()).rejects.toMatchObject({ message: 'HasSession failed' });
+            expect(fetch.mock.calls.length).toBe(1);
+            expect(fetch.mock.calls[0][0]).toMatch(/^http:\/\/id.e.com\//);
+        });
+
         test('should terminate "chain" if session-service call succeeds', async () => {
             const options = { clientId: 'foo', redirectUri: 'http://e.com', sessionDomain: 'http://id.e.com' };
             const client_sdrn = `sdrn:schibsted:client:${options.clientId}`;

--- a/__tests__/identity.js
+++ b/__tests__/identity.js
@@ -408,8 +408,8 @@ describe('Identity', () => {
             expect(fetch.mock.calls[0][0]).toMatch(/^http:\/\/id.e.com\//);
         });
 
-        test('should fail `hasSession` if session cookie is present but no session is found', async () => {
-            const options = { clientId: 'foo', redirectUri: 'http://e.com', sessionDomain: 'http://id.e.com' };
+        test('should fail `hasSession` if session cookie is present but no session is found and site does not have specific logout', async () => {
+            const options = { clientId: 'foo', redirectUri: 'http://e.com', sessionDomain: 'http://id.e.com', siteSpecificLogout: false };
             const client_sdrn = `sdrn:schibsted:client:${options.clientId}`;
             identity = new Identity(options);
             identity._sessionService = new RESTClient({

--- a/src/identity.js
+++ b/src/identity.js
@@ -436,93 +436,77 @@ export class Identity extends EventEmitter {
      * @return {Promise<Identity#HasSessionSuccessResponse|Identity#HasSessionFailureResponse>}
      */
     hasSession(autologin = true) {
-        if (this._hasSessionInProgress) {
-            return this._hasSessionInProgress;
-        }
-        const promiseFn = async (resolve, reject) => {
-            const postProcess = (sessionData) => {
+        if (!this._hasSessionInProgress) {
+            if (typeof autologin !== 'boolean') {
+                const [type, value] = inspect(autologin);
+                return Promise.reject(new SDKError(`Parameter 'autologin' must be boolean, was: "${type}:${value}"`));
+            }
+            const _postProcess = (sessionData) => {
                 if (sessionData.error) {
-                    this.emit('error', sessionData.error);
-                    return reject(new SDKError('HasSession failed', sessionData.error));
+                    throw new SDKError('HasSession failed', sessionData.error);
                 }
                 this._maybeSetVarnishCookie(sessionData);
                 this._emitSessionEvent(this._session, sessionData);
             };
-
-            if (typeof autologin !== 'boolean') {
-                const [type, value] = inspect(autologin);
-                return reject(new SDKError(`Parameter 'autologin' must be boolean, was: "${type}:${value}"`));
-            }
-
-            try {
+            const _getSession = async () => {
+                let sessionData = null;
                 if (this._enableSessionCaching) {
                     // Try to resolve from cache (it has a TTL)
-                    const cachedData = this.cache.get(HAS_SESSION_CACHE_KEY);
-                    if (cachedData) {
-                        postProcess(cachedData);
-                        return resolve(cachedData);
-                    }
+                    sessionData = this.cache.get(HAS_SESSION_CACHE_KEY);
                 }
-
-                let data = null;
-                if (this._sessionService) {
+                if (!sessionData && this._sessionService) {
                     try {
-                        data = await this._sessionService.get('/session');
-                    } catch (err) {	
+                        sessionData = await this._sessionService.get('/session');
+                    } catch (err) {
                         if (this.siteSpecificLogout) {
                             // Don't fallback to other sources for user session lookup
                             throw err;
                         }
 
-                        // The session-service returns 400 if no session-cookie is sent in the	
-                        // request. This will be the case if the user hasn't logged in since the	
-                        // site switched to using the session-service. If the request contains a	
-                        // session-cookie but no session is found (return code will be 404), then we	
-                        // *should* throw an exception and *not* fall through to spid-hassession	
-                        if (err.code !== 400) {	
-                            this.emit('error', err);	
-                            return reject(new SDKError('HasSession failed', err));	
-                        }	
-                        data = null;	
+                        // The session-service returns 400 if no session-cookie is sent in the
+                        // request. This will be the case if the user hasn't logged in since the
+                        // site switched to using the session-service. If the request contains a
+                        // session-cookie but no session is found (return code will be 404), then we
+                        // *should* throw an exception and *not* fall through to spid-hassession
+                        if (err.code !== 400) {
+                            throw err;
+                        }
                     }
                 }
+
                 const autoLoginConverted = autologin ? 1 : 0;
-
-                if (!data && !this._itpMode) {
-                    data = await this._hasSession.get('rpc/hasSession.js', { autologin: autoLoginConverted });
+                if (!sessionData && !this._itpMode) {
+                    sessionData = await this._hasSession.get('rpc/hasSession.js', { autologin: autoLoginConverted });
                 }
-                if (this._itpMode || (isObject(data.error) && data.error.type === 'LoginException')) {
-                    data = await this._spid.get('ajax/hasSession.js', { autologin: autoLoginConverted });
+                if (this._itpMode || (sessionData && isObject(sessionData.error) && sessionData.error.type === 'LoginException')) {
+                    sessionData = await this._spid.get('ajax/hasSession.js', { autologin: autoLoginConverted });
                 }
 
-                const shouldShowItpModal = this._itpModalRequired() && !this._itpMode &&
-                    isObject(data.error) && data.error.type === 'UserException' &&
-                    this.cache.get(LOGIN_IN_PROGRESS_KEY) !== null;
+                const shouldShowItpModal = this._itpModalRequired() && !this._itpMode && sessionData && isObject(sessionData.error)
+                    && sessionData.error.type === 'UserException' && this.cache.get(LOGIN_IN_PROGRESS_KEY) !== null;
                 if (shouldShowItpModal) {
                     this.cache.delete(LOGIN_IN_PROGRESS_KEY);
                     const modal = new ItpModal(this._spid, this.clientId, this.redirectUri, this.env);
-                    data = await modal.show();
+                    sessionData = await modal.show()
                 }
-                if (this._enableSessionCaching) {
-                    const expiresIn = 1000 * (data.expiresIn || 300);
-                    this.cache.set(HAS_SESSION_CACHE_KEY, data, expiresIn);
+                if (sessionData && this._enableSessionCaching) {
+                    const expiresIn = 1000 * (sessionData.expiresIn || 300);
+                    this.cache.set(HAS_SESSION_CACHE_KEY, sessionData, expiresIn);
                 }
-                postProcess(data);
-                this._session = data;
-                resolve(data);
-            } catch (err) {
-                this.emit('error', err);
-                reject(new SDKError('HasSession failed', err));
-            }
-        };
-        const promise = new Promise(promiseFn);
-        this._hasSessionInProgress = promise.then(v => {
-            this._hasSessionInProgress = null;
-            return v;
-        }, e => {
-            this._hasSessionInProgress = null;
-            throw e;
-        });
+                _postProcess(sessionData);
+                this._session = sessionData;
+                return sessionData;
+            };
+            this._hasSessionInProgress = _getSession()
+                .catch(err => {
+                    this.emit('error', err);
+                    throw new SDKError('HasSession failed', err);
+                })
+                .finally(() => {
+                    this._hasSessionInProgress = false;
+                });
+        }
+
         return this._hasSessionInProgress;
     }
 

--- a/src/identity.js
+++ b/src/identity.js
@@ -498,13 +498,17 @@ export class Identity extends EventEmitter {
                 return sessionData;
             };
             this._hasSessionInProgress = _getSession()
-                .catch(err => {
-                    this.emit('error', err);
-                    throw new SDKError('HasSession failed', err);
-                })
-                .finally(() => {
-                    this._hasSessionInProgress = false;
-                });
+                .then(
+                    sessionData => {
+                        this._hasSessionInProgress = false;
+                        return sessionData;
+                    },
+                    err => {
+                        this.emit('error', err);
+                        this._hasSessionInProgress = false;
+                        throw new SDKError('HasSession failed', err);
+                    }
+                );
         }
 
         return this._hasSessionInProgress;


### PR DESCRIPTION
The errors and symptoms we fix here are very similar to the ones tackled in #112.

IE11 chokes on the current setup with an asynchronous Promise executor
under certain circumstances. This change utilizes asynchronous functions
instead to achieve the same functionality as before.

Additionally, it simplifies logic slightly by reorganizing internal error
handling, event triggering and session data post processing.