### PR TITLE
Remove support for old login flows

### DIFF
--- a/__tests__/identity.js
+++ b/__tests__/identity.js
@@ -59,7 +59,7 @@ describe('Identity', () => {
             identity.login({ state: 'foo' });
             compareUrls(
                 window.location.href,
-                'https://identity-pre.schibsted.com/oauth/authorize?client_id=foo&redirect_uri=http%3A%2F%2Ffoo.com&response_type=code&new-flow=true&scope=openid&state=foo&prompt=select_account'
+                'https://identity-pre.schibsted.com/oauth/authorize?client_id=foo&redirect_uri=http%3A%2F%2Ffoo.com&response_type=code&scope=openid&state=foo&prompt=select_account'
             );
         });
         test('Should work with only "state" param for site specific logout', () => {
@@ -68,7 +68,7 @@ describe('Identity', () => {
             identity.login({ state: 'foo' });
             compareUrls(
                 window.location.href,
-                'https://identity-pre.schibsted.com/oauth/authorize?client_id=foo&redirect_uri=http%3A%2F%2Ffoo.com&response_type=code&new-flow=true&scope=openid&state=foo&prompt=select_account'
+                'https://identity-pre.schibsted.com/oauth/authorize?client_id=foo&redirect_uri=http%3A%2F%2Ffoo.com&response_type=code&scope=openid&state=foo&prompt=select_account'
             );
         });
         test('Should open popup if "preferPopup" is true', () => {
@@ -83,7 +83,7 @@ describe('Identity', () => {
             identity.login({ state: 'foo', preferPopup: true });
             compareUrls(
                 window.location.href,
-                'https://identity-pre.schibsted.com/oauth/authorize?client_id=foo&redirect_uri=http%3A%2F%2Ffoo.com&response_type=code&new-flow=true&scope=openid&state=foo&prompt=select_account'
+                'https://identity-pre.schibsted.com/oauth/authorize?client_id=foo&redirect_uri=http%3A%2F%2Ffoo.com&response_type=code&scope=openid&state=foo&prompt=select_account'
             );
         });
         test('Should close previous popup if it exists (and is open)', () => {
@@ -151,24 +151,6 @@ describe('Identity', () => {
     });
 
     describe('loginUrl() with options object', () => {
-        test('returns the expected endpoint for old flows', () => {
-            const identity = new Identity({
-                env: 'PRO_NO',
-                clientId: 'foo',
-                redirectUri: 'http://example.com',
-                window: {},
-            });
-            compareUrls(identity.loginUrl({
-                state: 'dummy-state',
-                acrValues: 'otp-email',
-                newFlow: false,
-                loginHint: 'dev@spid.no',
-                tag: 'sample-tag',
-                teaser: 'sample-teaser-slug',
-                locale: 'en_US'
-            }), 'https://payment.schibsted.no/flow/login?client_id=foo&state=dummy-state&scope=openid&response_type=code&redirect_uri=http%3A%2F%2Fexample.com&email=dev@spid.no&tag=sample-tag&teaser=sample-teaser-slug&locale=en_US');
-        });
-
         test('returns the expected endpoint for new flows', () => {
             const identity = new Identity({
                 env: 'PRO',
@@ -178,14 +160,13 @@ describe('Identity', () => {
             });
             compareUrls(identity.loginUrl({
                 state: 'dummy-state',
-                newFlow: true,
                 loginHint: 'dev@spid.no',
                 tag: 'sample-tag',
                 teaser: 'sample-teaser-slug',
                 maxAge: 0,
                 locale: 'en_US',
                 oneStepLogin: true
-            }), 'https://login.schibsted.com/oauth/authorize?new-flow=true&redirect_uri=http%3A%2F%2Fexample.com&client_id=foo&state=dummy-state&response_type=code&scope=openid&login_hint=dev@spid.no&max_age=0&tag=sample-tag&teaser=sample-teaser-slug&locale=en_US&one_step_login=true&prompt=select_account');
+            }), 'https://login.schibsted.com/oauth/authorize?redirect_uri=http%3A%2F%2Fexample.com&client_id=foo&state=dummy-state&response_type=code&scope=openid&login_hint=dev@spid.no&max_age=0&tag=sample-tag&teaser=sample-teaser-slug&locale=en_US&one_step_login=true&prompt=select_account');
         });
 
         test('returns the expected endpoint for new flows, with siteSpecificLogout', () => {
@@ -198,14 +179,13 @@ describe('Identity', () => {
             });
             compareUrls(identity.loginUrl({
                 state: 'dummy-state',
-                newFlow: true,
                 loginHint: 'dev@spid.no',
                 tag: 'sample-tag',
                 teaser: 'sample-teaser-slug',
                 maxAge: 0,
                 locale: 'en_US',
                 oneStepLogin: true
-            }), 'https://login.schibsted.com/oauth/authorize?new-flow=true&redirect_uri=http%3A%2F%2Fexample.com&client_id=foo&state=dummy-state&response_type=code&scope=openid&login_hint=dev@spid.no&max_age=0&tag=sample-tag&teaser=sample-teaser-slug&locale=en_US&one_step_login=true&prompt=select_account');
+            }), 'https://login.schibsted.com/oauth/authorize?redirect_uri=http%3A%2F%2Fexample.com&client_id=foo&state=dummy-state&response_type=code&scope=openid&login_hint=dev@spid.no&max_age=0&tag=sample-tag&teaser=sample-teaser-slug&locale=en_US&one_step_login=true&prompt=select_account');
         });
 
         test('returns the expected endpoint for new flows with default params', () => {
@@ -217,30 +197,11 @@ describe('Identity', () => {
             });
             compareUrls(identity.loginUrl({
                 state: 'dummy-state',
-            }), 'https://login.schibsted.com/oauth/authorize?new-flow=true&redirect_uri=http%3A%2F%2Fexample.com&client_id=foo&state=dummy-state&response_type=code&scope=openid&prompt=select_account');
+            }), 'https://login.schibsted.com/oauth/authorize?redirect_uri=http%3A%2F%2Fexample.com&client_id=foo&state=dummy-state&response_type=code&scope=openid&prompt=select_account');
         });
     });
 
     describe('loginUrl() with arguments', () => {
-        test('returns the expected endpoint for old flows', () => {
-            const identity = new Identity({
-                env: 'PRO_NO',
-                clientId: 'foo',
-                redirectUri: 'http://example.com',
-                window: {},
-            });
-            compareUrls(identity.loginUrl(
-                'dummy-state',
-                'otp-email',
-                undefined,
-                undefined,
-                false,
-                'dev@spid.no',
-                'sample-tag',
-                'sample-teaser-slug'
-            ), 'https://payment.schibsted.no/flow/login?client_id=foo&state=dummy-state&scope=openid&response_type=code&redirect_uri=http%3A%2F%2Fexample.com&email=dev@spid.no&tag=sample-tag&teaser=sample-teaser-slug');
-        });
-
         test('returns the expected endpoint for new flows', () => {
             const identity = new Identity({
                 env: 'PRO',
@@ -254,12 +215,11 @@ describe('Identity', () => {
                 undefined,
                 undefined,
                 undefined,
-                true,
                 'dev@spid.no',
                 'sample-tag',
                 'sample-teaser-slug',
                 0
-            ), 'https://login.schibsted.com/oauth/authorize?new-flow=true&redirect_uri=http%3A%2F%2Fexample.com&client_id=foo&state=dummy-state&response_type=code&scope=openid&login_hint=dev@spid.no&max_age=0&tag=sample-tag&teaser=sample-teaser-slug&prompt=select_account');
+            ), 'https://login.schibsted.com/oauth/authorize?redirect_uri=http%3A%2F%2Fexample.com&client_id=foo&state=dummy-state&response_type=code&scope=openid&login_hint=dev@spid.no&max_age=0&tag=sample-tag&teaser=sample-teaser-slug&prompt=select_account');
         });
 
         test('returns the expected endpoint for new flows with default params', () => {
@@ -274,7 +234,7 @@ describe('Identity', () => {
                 undefined,
                 undefined,
                 undefined,
-            ), 'https://login.schibsted.com/oauth/authorize?new-flow=true&redirect_uri=http%3A%2F%2Fexample.com&client_id=foo&state=dummy-state&response_type=code&scope=openid&prompt=select_account');
+            ), 'https://login.schibsted.com/oauth/authorize?redirect_uri=http%3A%2F%2Fexample.com&client_id=foo&state=dummy-state&response_type=code&scope=openid&prompt=select_account');
         });
 
         test('returns the expected endpoint for new flows with siteSpecificLogout=true', () => {
@@ -290,7 +250,7 @@ describe('Identity', () => {
                 undefined,
                 undefined,
                 undefined,
-            ), 'https://login.schibsted.com/oauth/authorize?new-flow=true&redirect_uri=http%3A%2F%2Fexample.com&client_id=foo&state=dummy-state&response_type=code&scope=openid&prompt=select_account');
+            ), 'https://login.schibsted.com/oauth/authorize?redirect_uri=http%3A%2F%2Fexample.com&client_id=foo&state=dummy-state&response_type=code&scope=openid&prompt=select_account');
         });
     });
 

--- a/__tests__/identity.js
+++ b/__tests__/identity.js
@@ -785,9 +785,6 @@ describe('Identity', () => {
                 ['accountUrl', '/account/summary'],
                 ['phonesUrl', '/account/phones'],
                 ['logoutUrl', '/logout'],
-                ['authFlowUrl', '/flow/auth'],
-                ['signupFlowUrl', '/flow/signup'],
-                ['signinFlowUrl', '/flow/signin'],
             ];
             test.each(urlFunctions)('%s -> %s', (func, pathname) => {
                 const identity = new Identity({ clientId: 'foo', redirectUri: 'http://example.com' });

--- a/src/identity.js
+++ b/src/identity.js
@@ -677,8 +677,6 @@ export class Identity extends EventEmitter {
      * @param {string} [options.redirectUri=this.redirectUri] - Redirect uri that will receive the
      * code. Must exactly match a redirectUri from your client in self-service
      * @param {boolean} [options.preferPopup=false] - Should we try to open a popup window?
-     * @param {boolean} [options.newFlow=true] - Should we try the new GDPR-safe flow or the
-     * legacy/stable SPiD flow?
      * @param {string} [options.loginHint=''] - user email or UUID hint
      * @param {string} [options.tag=''] - Pulse tag
      * @param {string} [options.teaser=''] - Teaser slug. Teaser with given slug will be displayed
@@ -698,7 +696,6 @@ export class Identity extends EventEmitter {
         scope = 'openid',
         redirectUri = this.redirectUri,
         preferPopup = false,
-        newFlow = true,
         loginHint = '',
         tag = '',
         teaser = '',
@@ -708,7 +705,7 @@ export class Identity extends EventEmitter {
     }) {
         this._closePopup();
         this.cache.delete(HAS_SESSION_CACHE_KEY);
-        const url = this.loginUrl({ state, acrValues, scope, redirectUri, newFlow, loginHint, tag,
+        const url = this.loginUrl({ state, acrValues, scope, redirectUri, loginHint, tag,
             teaser, maxAge, locale, oneStepLogin });
 
         this.showItpModalUponReturning();
@@ -745,12 +742,9 @@ export class Identity extends EventEmitter {
      * @see https://tools.ietf.org/html/rfc6749#section-10.12
      * @param {string} [options.acrValues] - Authentication method. If omitted, user authenticates with
      * username+password. If set to `'otp-email'`, then  passwordless login using email is used. If
-     * `'otp-sms'`, then passwordless login using sms is used. Please note that this parameter has
-     * no effect if `newFlow` is false
+     * `'otp-sms'`, then passwordless login using sms is used.
      * @param {string} [options.scope='openid']
      * @param {string} [options.redirectUri=this.redirectUri]
-     * @param {boolean} [options.newFlow=true] - Should we try the new flow or the old Schibsted account
-     * login? If this parameter is set to false, the `acrValues` parameter doesn't have any effect
      * @param {string} [options.loginHint=''] - user email or UUID hint
      * @param {string} [options.tag=''] - Pulse tag
      * @param {string} [options.teaser=''] - Teaser slug. Teaser with given slug will be displayed
@@ -769,7 +763,6 @@ export class Identity extends EventEmitter {
         acrValues,
         scope = 'openid',
         redirectUri = this.redirectUri,
-        newFlow = true,
         loginHint = '',
         tag = '',
         teaser = '',
@@ -783,11 +776,10 @@ export class Identity extends EventEmitter {
             acrValues = arguments[1];
             scope = arguments[2] || scope;
             redirectUri = arguments[3] || redirectUri;
-            newFlow = typeof arguments[4] === 'boolean' ? arguments[4] : newFlow;
-            loginHint = arguments[5] || loginHint;
-            tag = arguments[6] || tag;
-            teaser = arguments[7] || teaser;
-            maxAge = isNaN(arguments[8]) ? maxAge : arguments[8];
+            loginHint = arguments[4] || loginHint;
+            tag = arguments[5] || tag;
+            teaser = arguments[6] || teaser;
+            maxAge = isNaN(arguments[7]) ? maxAge : arguments[7];
         }
         assert(!acrValues || isStrIn(acrValues, ['', 'otp-email', 'otp-sms'], true),
             `The acrValues parameter is not acceptable: ${acrValues}`);
@@ -796,36 +788,20 @@ export class Identity extends EventEmitter {
         assert(isNonEmptyString(state),
             `the state parameter should be a non empty string but it is ${state}`);
 
-
-        if (newFlow) {
-            return this._oauthService.makeUrl('oauth/authorize', {
-                response_type: 'code',
-                'new-flow': true,
-                redirect_uri: redirectUri,
-                scope,
-                state,
-                acr_values: acrValues,
-                login_hint: loginHint,
-                tag,
-                teaser,
-                max_age: maxAge,
-                locale,
-                one_step_login: oneStepLogin || '',
-                prompt: this.siteSpecificLogout ? 'select_account' : ''
-            });
-        } else {
-            // acrValues do not work with the old flows
-            return this._spid.makeUrl('flow/login', {
-                response_type: 'code',
-                redirect_uri: redirectUri,
-                scope,
-                state,
-                email: loginHint,
-                tag,
-                teaser,
-                locale
-            });
-        }
+        return this._oauthService.makeUrl('oauth/authorize', {
+            response_type: 'code',
+            redirect_uri: redirectUri,
+            scope,
+            state,
+            acr_values: acrValues,
+            login_hint: loginHint,
+            tag,
+            teaser,
+            max_age: maxAge,
+            locale,
+            one_step_login: oneStepLogin || '',
+            prompt: this.siteSpecificLogout ? 'select_account' : ''
+        });
     }
 
     /**

--- a/src/identity.js
+++ b/src/identity.js
@@ -844,48 +844,6 @@ export class Identity extends EventEmitter {
     }
 
     /**
-     * Url to render either signup or login
-     * @see https://techdocs.spid.no/flows/auth-flow/
-     * @param {string} [redirectUri=this.redirectUri]
-     * @return {string} - the url to the authentication page
-     */
-    authFlowUrl(redirectUri = this.redirectUri) {
-        assert(isUrl(redirectUri), `authFlowUrl(): redirectUri is invalid`);
-        return this._spid.makeUrl('flow/auth', {
-            response_type: 'code',
-            redirect_uri: redirectUri
-        });
-    }
-
-    /**
-     * Url to render a signup view and let the user login with credentials
-     * @see https://techdocs.spid.no/flows/auth-flow/
-     * @param {string} [redirectUri=this.redirectUri]
-     * @return {string} - the url to the signup page
-     */
-    signupFlowUrl(redirectUri = this.redirectUri) {
-        assert(isUrl(redirectUri), `signupFlowUrl(): redirectUri is invalid`);
-        return this._spid.makeUrl('flow/signup', {
-            response_type: 'code',
-            redirect_uri: redirectUri
-        });
-    }
-
-    /**
-     * To render a signin view and let the user login without credentials
-     * @see https://techdocs.spid.no/flows/auth-flow/
-     * @param {string} [redirectUri=this.redirectUri]
-     * @return {string} - the url to the signin page
-     */
-    signinFlowUrl(redirectUri = this.redirectUri) {
-        assert(isUrl(redirectUri), `signinFlowUrl(): redirectUri is invalid`);
-        return this._spid.makeUrl('flow/signin', {
-            response_type: 'code',
-            redirect_uri: redirectUri
-        });
-    }
-
-    /**
      * Call this method immediately before sending a user to a Schibsted account flow if you
      * want to enable showing of the ITP modal upon returning to your site. You should
      * send the user to a Schibsted account flow immediately after calling this method without


### PR DESCRIPTION
It was deprecated and removed 16th Aug 2020 and the 'new-flow=true'
parameter is no longer required.
