### PR TITLE
Clear client side caches, if referred from account pages

### DIFF
--- a/src/identity.js
+++ b/src/identity.js
@@ -7,6 +7,7 @@
 import { assert, isStr, isNonEmptyString, isObject, isUrl, isStrIn } from './validate';
 import { cloneDeep } from './object';
 import { urlMapper } from './url';
+import { isReferredFromAccountPages } from './util';
 import { ENDPOINTS, NAMESPACE } from './config';
 import EventEmitter from 'tiny-emitter';
 import Cache from './cache';
@@ -113,6 +114,9 @@ export class Identity extends EventEmitter {
         this._setBffServerUrl(env);
         this._setOauthServerUrl(env);
         this._setGlobalSessionServiceUrl(env);
+        if (isReferredFromAccountPages(window.location && window.location.referer, env)) {
+            this.cache.delete(HAS_SESSION_CACHE_KEY);
+        }
     }
 
     /**

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,5 @@
+import { ENDPOINTS } from './config';
+
+export const isReferredFromAccountPages = (referrer, env) => {
+    return referrer && (referrer.startsWith(ENDPOINTS.BFF[env]) || referrer.startsWith(ENDPOINTS.SPiD[env]));
+};


### PR DESCRIPTION
# WHAT
Whenever a client has a referring url from some account page the hasSession and hasAccess client side caches are cleared.

# WHY
When users have just been to account pages, it is very likely that the user state has somehow been updated.
This could be implemented on the client sites, but is really not optimal, since clients then need to be aware of how the caching in the account sdk works.

This method does unfortunately not cover cases when users are automatically logged in without interaction in the login flow. 
In these cases we have to rely on that the logins are made through the skd with the Identity.login method, which has a cache clear built in to it.

# Alternative solution considered:
Set a short lived client side readable cookie (that is _not_ http-only) in the session-service, marking that the user state might be "dirty".
Trigger on that cookie in the browser sdk, instead of watching the referrer url.