### PR TITLE
simplifiedLoginWidget options should be optional

### DIFF
--- a/src/identity.d.ts
+++ b/src/identity.d.ts
@@ -299,7 +299,7 @@ export class Identity {
      * @async
      * @param {LoginOptions} loginParams - the same as `options` param for login function. Login will be called on user
      * continue action. `state` might be string or async function.
-     * @param {SimplifiedLoginWidgetOptions} options - additional configuration of Simplified Login Widget
+     * @param {SimplifiedLoginWidgetOptions} [options] - additional configuration of Simplified Login Widget
      * @return {Promise<boolean|SDKError>} - will resolve to true if widget will be display. Otherwise will throw SDKError
      */
     showSimplifiedLoginWidget(loginParams: LoginOptions, options?: SimplifiedLoginWidgetOptions): Promise<boolean | SDKError>;

--- a/src/identity.d.ts
+++ b/src/identity.d.ts
@@ -302,7 +302,7 @@ export class Identity {
      * @param {SimplifiedLoginWidgetOptions} options - additional configuration of Simplified Login Widget
      * @return {Promise<boolean|SDKError>} - will resolve to true if widget will be display. Otherwise will throw SDKError
      */
-    showSimplifiedLoginWidget(loginParams: LoginOptions, options: SimplifiedLoginWidgetOptions): Promise<boolean | SDKError>;
+    showSimplifiedLoginWidget(loginParams: LoginOptions, options?: SimplifiedLoginWidgetOptions): Promise<boolean | SDKError>;
 }
 export default Identity;
 export type LoginOptions = {

--- a/src/identity.js
+++ b/src/identity.js
@@ -818,7 +818,7 @@ export class Identity extends EventEmitter {
      * @param {SimplifiedLoginWidgetOptions} options - additional configuration of Simplified Login Widget
      * @return {Promise<boolean|SDKError>} - will resolve to true if widget will be display. Otherwise will throw SDKError
      */
-    async showSimplifiedLoginWidget(loginParams, options) {
+    async showSimplifiedLoginWidget(loginParams, options?) {
         // getUserContextData doens't throw exception
         const userData = await this.getUserContextData();
 

--- a/src/identity.js
+++ b/src/identity.js
@@ -815,17 +815,17 @@ export class Identity extends EventEmitter {
      * @async
      * @param {LoginOptions} loginParams - the same as `options` param for login function. Login will be called on user
      * continue action. `state` might be string or async function.
-     * @param {SimplifiedLoginWidgetOptions} options - additional configuration of Simplified Login Widget
+     * @param {SimplifiedLoginWidgetOptions} [options] - additional configuration of Simplified Login Widget
      * @return {Promise<boolean|SDKError>} - will resolve to true if widget will be display. Otherwise will throw SDKError
      */
-    async showSimplifiedLoginWidget(loginParams, options?) {
+    async showSimplifiedLoginWidget(loginParams, options) {
         // getUserContextData doens't throw exception
         const userData = await this.getUserContextData();
 
         const queryParams = { client_id: this.clientId };
         if (options && options.encoding) {
             queryParams.encoding = options.encoding;
-        } 
+        }
         const widgetUrl = this._bffService.makeUrl('simplified-login-widget', queryParams, false);
 
         const prepareLoginParams = async (loginPrams) => {


### PR DESCRIPTION
New parameter in v4.4.0 breaks any existing implementation of showSimplifiedLoginWidget since the new option is not specified as optional even tho the code expects it to be optional