### PR TITLE
Marked purchasePromoCodeProductFlowUrl as deprecated

### DIFF
--- a/src/payment.d.ts
+++ b/src/payment.d.ts
@@ -101,6 +101,7 @@ export class Payment {
      */
     purchaseCampaignFlowUrl(campaignId: string, productId: string, voucherCode?: string, redirectUri?: string): string;
     /**
+     * @deprecated
      * Get the url for flow to purchase a promo code product with ZUORA
      * @param {string} code - promocode product code
      * @param {string} [state=''] - An opaque value used by the client to maintain state between

--- a/src/payment.js
+++ b/src/payment.js
@@ -185,6 +185,7 @@ export class Payment {
     }
 
     /**
+     * @deprecated
      * Get the url for flow to purchase a promo code product with ZUORA
      * @param {string} code - promocode product code
      * @param {string} [state=''] - An opaque value used by the client to maintain state between


### PR DESCRIPTION
Clients should not use that function anymore, they should generate urls on their own (as for now). 