### PR TITLE
Update link to Travis CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![logo](https://www.schibsted.com/Global/LogoTypes/Logos%202014/SMG_Small_2014_RGB.png)](https://github.com/schibsted/account-sdk-browser)
 
-[![Build Status](https://travis-ci.com/schibsted/account-sdk-browser.svg?branch=master)](https://travis-ci.com/schibsted/account-sdk-browser)
+[![Build Status](https://app.travis-ci.com/schibsted/account-sdk-browser.svg?branch=master)](https://app.travis-ci.com/schibsted/account-sdk-browser)
 [![Code coverage](https://codecov.io/gh/schibsted/account-sdk-browser/branch/master/graph/badge.svg)](https://codecov.io/gh/schibsted/account-sdk-browser)
 [![Snyk](https://snyk.io/test/github/schibsted/account-sdk-browser/badge.svg?targetFile=package.json)](https://snyk.io/test/github/schibsted/account-sdk-browser)
 


### PR DESCRIPTION
Travis CI is available under the new location - link in `README.md` was outdated