### PR TITLE
fix: improve Identity types

### DIFF
--- a/src/identity.d.ts
+++ b/src/identity.d.ts
@@ -1,7 +1,7 @@
 /**
- * Provides Identity functionalty to a web page
+ * Provides Identity functionality to a web page
  */
-export class Identity {
+export class Identity extends EventEmitter {
     /**
      * @param {object} options
      * @param {string} options.clientId - Example: "1234567890abcdef12345678"

--- a/src/identity.d.ts
+++ b/src/identity.d.ts
@@ -1,7 +1,9 @@
+import type { TinyEmitter } from 'tiny-emitter';
+
 /**
  * Provides Identity functionality to a web page
  */
-export class Identity extends EventEmitter {
+export class Identity extends TinyEmitter {
     /**
      * @param {object} options
      * @param {string} options.clientId - Example: "1234567890abcdef12345678"


### PR DESCRIPTION
Class Identity extends EventEmitter in the JS file, but it's not typed for TS.