### PR TITLE
Add open & cancel events to SimplifiedLoginWidget

### DIFF
--- a/__tests__/identity.js
+++ b/__tests__/identity.js
@@ -957,6 +957,47 @@ describe('Identity', () => {
             expect(document.getElementsByTagName('body')[0].appendChild).toHaveBeenCalledTimes(1);
             expect(window.openSimplifiedLoginWidget).toHaveBeenCalledTimes(1);
         });
+
+        test('Should emit simplifiedLoginOpened if loaded successfully', async () => {
+            const spy = jest.fn();
+
+            identity._globalSessionService.fetch = jest.fn(() => ({ ok: true, json: () => expectedData }));
+            identity.login = jest.fn();
+
+            document.getElementsByTagName('body')[0].appendChild = jest.fn((el) => {
+                window.openSimplifiedLoginWidget = jest.fn(async () => {
+                    return true;
+                });
+
+                el.onload();
+            });
+
+            identity.on('simplifiedLoginOpened', spy);
+
+            expect(await identity.showSimplifiedLoginWidget({ state })).toEqual(true);
+            expect(document.getElementsByTagName('body')[0].appendChild).toHaveBeenCalledTimes(1);
+            expect(window.openSimplifiedLoginWidget).toHaveBeenCalledTimes(1);
+            expect(spy).toHaveBeenCalledTimes(1);
+        })
+
+        test('Should emit simplifiedLoginCancelled after closing the widget', async () => {
+            const spy = jest.fn();
+            identity._globalSessionService.fetch = jest.fn(() => ({ ok: true, json: () => expectedData }));
+            identity.on('simplifiedLoginCancelled', spy)
+
+            document.getElementsByTagName('body')[0].appendChild = jest.fn((el) => {
+                window.openSimplifiedLoginWidget = jest.fn(async (initialParams, loginHandler, loginNotYouHandler, cancelHandler) => {
+                    cancelHandler();
+                });
+
+                el.onload();
+            });
+
+            expect(await identity.showSimplifiedLoginWidget({ state })).toEqual(true);
+            expect(document.getElementsByTagName('body')[0].appendChild).toHaveBeenCalledTimes(1);
+            expect(window.openSimplifiedLoginWidget).toHaveBeenCalledTimes(1);
+            expect(spy).toHaveBeenCalledTimes(1);
+        })
     });
 
     describe('logSettings', () => {

--- a/__tests__/identity.js
+++ b/__tests__/identity.js
@@ -757,6 +757,8 @@ describe('Identity', () => {
 
         beforeEach(() => {
             identity = new Identity({ clientId: 'foo', redirectUri: 'http://example.com', sessionDomain: 'http://id.example.com' });
+            identity._globalSessionService.fetch = jest.fn(() => ({ ok: true, json: () => expectedData }));
+            identity.login = jest.fn();
         });
 
         afterEach(() => {
@@ -961,40 +963,27 @@ describe('Identity', () => {
         test('Should emit simplifiedLoginOpened if loaded successfully', async () => {
             const spy = jest.fn();
 
-            identity._globalSessionService.fetch = jest.fn(() => ({ ok: true, json: () => expectedData }));
-            identity.login = jest.fn();
-
-            document.getElementsByTagName('body')[0].appendChild = jest.fn((el) => {
-                window.openSimplifiedLoginWidget = jest.fn(async () => {
-                    return true;
-                });
-
-                el.onload();
+            window.openSimplifiedLoginWidget = jest.fn(async (initialParams, loginHandler, loginNotYouHandler, initHandler) => {
+                initHandler();
             });
 
             identity.on('simplifiedLoginOpened', spy);
 
             expect(await identity.showSimplifiedLoginWidget({ state })).toEqual(true);
-            expect(document.getElementsByTagName('body')[0].appendChild).toHaveBeenCalledTimes(1);
             expect(window.openSimplifiedLoginWidget).toHaveBeenCalledTimes(1);
             expect(spy).toHaveBeenCalledTimes(1);
         })
 
         test('Should emit simplifiedLoginCancelled after closing the widget', async () => {
             const spy = jest.fn();
-            identity._globalSessionService.fetch = jest.fn(() => ({ ok: true, json: () => expectedData }));
+
             identity.on('simplifiedLoginCancelled', spy)
 
-            document.getElementsByTagName('body')[0].appendChild = jest.fn((el) => {
-                window.openSimplifiedLoginWidget = jest.fn(async (initialParams, loginHandler, loginNotYouHandler, cancelHandler) => {
-                    cancelHandler();
-                });
-
-                el.onload();
+            window.openSimplifiedLoginWidget = jest.fn(async (initialParams, loginHandler, loginNotYouHandler, initHandler, cancelHandler) => {
+                cancelHandler();
             });
 
             expect(await identity.showSimplifiedLoginWidget({ state })).toEqual(true);
-            expect(document.getElementsByTagName('body')[0].appendChild).toHaveBeenCalledTimes(1);
             expect(window.openSimplifiedLoginWidget).toHaveBeenCalledTimes(1);
             expect(spy).toHaveBeenCalledTimes(1);
         })

--- a/src/identity.js
+++ b/src/identity.js
@@ -902,6 +902,14 @@ export class Identity extends EventEmitter {
                     this.login(Object.assign(await prepareLoginParams(loginParams), {loginHint: userData.identifier, prompt: 'login'}));
                 };
 
+                const initHandler = () => {
+                    /**
+                     * Emitted when the simplified login widget is displayed on the screen
+                     * @event Identity#simplifiedLoginOpened
+                     */
+                    this.emit('simplifiedLoginOpened');
+                }
+
                 const cancelLoginHandler = () => {
                     /**
                      * Emitted when the user closes the simplified login widget
@@ -911,12 +919,7 @@ export class Identity extends EventEmitter {
                 }
 
                 if (window.openSimplifiedLoginWidget) {
-                    window.openSimplifiedLoginWidget(initialParams, loginHandler, loginNotYouHandler, cancelLoginHandler);
-                    /**
-                     * Emitted when the simplified login widget is displayed on the screen
-                     * @event Identity#simplifiedLoginOpened
-                     */
-                    this.emit('simplifiedLoginOpened');
+                    window.openSimplifiedLoginWidget(initialParams, loginHandler, loginNotYouHandler, initHandler, cancelLoginHandler);
                     return resolve(true);
                 }
 
@@ -924,8 +927,7 @@ export class Identity extends EventEmitter {
                 simplifiedLoginWidget.type = "text/javascript";
                 simplifiedLoginWidget.src = widgetUrl;
                 simplifiedLoginWidget.onload = () => {
-                    window.openSimplifiedLoginWidget(initialParams, loginHandler, loginNotYouHandler, cancelLoginHandler);
-                    this.emit('simplifiedLoginOpened');
+                    window.openSimplifiedLoginWidget(initialParams, loginHandler, loginNotYouHandler, initHandler, cancelLoginHandler);
                     resolve(true);
                 };
                 simplifiedLoginWidget.onerror = () => {

--- a/src/identity.js
+++ b/src/identity.js
@@ -849,7 +849,9 @@ export class Identity extends EventEmitter {
      * @param {SimplifiedLoginWidgetLoginOptions} loginParams - the same as `options` param for login function. Login will be called on user
      * continue action. `state` might be string or async function.
      * @param {SimplifiedLoginWidgetOptions} [options] - additional configuration of Simplified Login Widget
-     * @return {Promise<boolean|SDKError>} - will resolve to true if widget will be display. Otherwise will throw SDKError
+     * @fires Identity#simplifiedLoginOpened
+     * @fires Identity#simplifiedLoginCancelled
+     * @return {Promise<boolean|SDKError>} - will resolve to true if widget will be display. Otherwise, will throw SDKError
      */
     async showSimplifiedLoginWidget(loginParams, options) {
         // getUserContextData doesn't throw exception
@@ -900,8 +902,21 @@ export class Identity extends EventEmitter {
                     this.login(Object.assign(await prepareLoginParams(loginParams), {loginHint: userData.identifier, prompt: 'login'}));
                 };
 
+                const cancelLoginHandler = () => {
+                    /**
+                     * Emitted when the user closes the simplified login widget
+                     * @event Identity#simplifiedLoginCancelled
+                     */
+                    this.emit('simplifiedLoginCancelled');
+                }
+
                 if (window.openSimplifiedLoginWidget) {
-                    window.openSimplifiedLoginWidget(initialParams, loginHandler, loginNotYouHandler);
+                    window.openSimplifiedLoginWidget(initialParams, loginHandler, loginNotYouHandler, cancelLoginHandler);
+                    /**
+                     * Emitted when the simplified login widget is displayed on the screen
+                     * @event Identity#simplifiedLoginOpened
+                     */
+                    this.emit('simplifiedLoginOpened');
                     return resolve(true);
                 }
 
@@ -909,9 +924,10 @@ export class Identity extends EventEmitter {
                 simplifiedLoginWidget.type = "text/javascript";
                 simplifiedLoginWidget.src = widgetUrl;
                 simplifiedLoginWidget.onload = () => {
-                    window.openSimplifiedLoginWidget(initialParams, loginHandler, loginNotYouHandler);
+                    window.openSimplifiedLoginWidget(initialParams, loginHandler, loginNotYouHandler, cancelLoginHandler);
                     resolve(true);
                 };
+                this.emit('simplifiedLoginOpened');
                 simplifiedLoginWidget.onerror = () => {
                     reject(new SDKError('Error when loading simplified login widget content'));
                 };

--- a/src/identity.js
+++ b/src/identity.js
@@ -925,9 +925,9 @@ export class Identity extends EventEmitter {
                 simplifiedLoginWidget.src = widgetUrl;
                 simplifiedLoginWidget.onload = () => {
                     window.openSimplifiedLoginWidget(initialParams, loginHandler, loginNotYouHandler, cancelLoginHandler);
+                    this.emit('simplifiedLoginOpened');
                     resolve(true);
                 };
-                this.emit('simplifiedLoginOpened');
                 simplifiedLoginWidget.onerror = () => {
                     reject(new SDKError('Error when loading simplified login widget content'));
                 };


### PR DESCRIPTION
Description:
This PR adds 2 new events:
- `simplifiedLoginOpened` emitted when the widget loaded
- `simplifiedLoginCancelled` emitted when the user closes the widget without logging in