### PR TITLE
Generate version file instead of including pkg.json

### DIFF
--- a/__tests__/identity.js
+++ b/__tests__/identity.js
@@ -10,8 +10,7 @@ import Identity from '../identity.js';
 import { compareUrls, Fixtures } from './utils.js';
 import { URL } from 'url';
 import { URL as u } from 'whatwg-url';
-import packageJson from '../package.json';
-const { version } = packageJson;
+import version from '../src/version.js';
 
 describe('Identity', () => {
     const defaultOptions = {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "cover": "jest --coverage",
     "postcover": "codecov",
     "preversion": "npm test",
-    "version": "node ./scripts/genversion.js && git add src/version.js"
+    "version": "node ./scripts/genversion.js && git add src/version.js",
+    "postversion": "git push && git push --tags"
   },
   "author": "",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "cover": "jest --coverage",
     "postcover": "codecov",
     "preversion": "npm test",
-    "postversion": "git push && git push --tags"
+    "version": "node ./scripts/genversion.js && git add src/version.js"
   },
   "author": "",
   "license": "MIT",

--- a/scripts/genversion.js
+++ b/scripts/genversion.js
@@ -1,0 +1,17 @@
+import assert from 'node:assert';
+import { writeFileSync } from 'fs';
+
+// eslint-disable-next-line no-undef
+const version = process.env.npm_package_version;
+assert.match(version, /^\d+\.\d+\.\d+(-\w+)?$/, `Version '${version}' is not valid`);
+
+// eslint-disable-next-line no-undef
+const filename = `${ process.cwd() }/src/version.js`;
+const content = `// Automatically generated in 'npm version' by scripts/genversion.js
+
+'use strict'
+const version = '${ version }';
+export default version;
+`;
+
+writeFileSync(filename, content, 'utf8');

--- a/src/identity.js
+++ b/src/identity.js
@@ -14,8 +14,7 @@ import * as popup from './popup.js';
 import RESTClient from './RESTClient.js';
 import SDKError from './SDKError.js';
 import * as spidTalk from './spidTalk.js';
-import packageJson from '../package.json';
-const { version } = packageJson;
+import version from './version.js';
 
 /**
  * @typedef {object} LoginOptions

--- a/src/monetization.js
+++ b/src/monetization.js
@@ -12,8 +12,7 @@ import RESTClient from './RESTClient.js';
 import Cache from './cache.js';
 import * as spidTalk from './spidTalk.js';
 import SDKError from './SDKError.js';
-import packageJson from '../package.json';
-const { version } = packageJson;
+import version from './version.js';
 
 const globalWindow = () => window;
 

--- a/src/version.d.ts
+++ b/src/version.d.ts
@@ -1,0 +1,2 @@
+declare const version: string;
+export default version;

--- a/src/version.js
+++ b/src/version.js
@@ -1,0 +1,5 @@
+// Automatically generated in 'npm version' by scripts/genversion.js
+
+'use strict'
+const version = '4.8.1';
+export default version;


### PR DESCRIPTION
Including json files in ESM is messy, especially if not running webpack that can resolve files.
Including the package.json also means it gets included in the built file, which likely is not what we want.

This PR generates are version file when you run `npm version` and adds it to the tagged commit.