### PR TITLE
fix: ES modules import in TS files

### DIFF
--- a/src/identity.d.ts
+++ b/src/identity.d.ts
@@ -610,5 +610,5 @@ export type SimplifiedLoginWidgetOptions = {
      */
     locale?: "nb"|"sv"|"fi"|"da"|"en";
 };
-import RESTClient from "./RESTClient";
-import SDKError from "./SDKError";
+import RESTClient from "./RESTClient.js";
+import SDKError from "./SDKError.js";

--- a/src/monetization.d.ts
+++ b/src/monetization.d.ts
@@ -77,4 +77,4 @@ export class Monetization {
     productsUrl(redirectUri?: string): string;
 }
 export default Monetization;
-import RESTClient from "./RESTClient";
+import RESTClient from "./RESTClient.js";

--- a/src/payment.d.ts
+++ b/src/payment.d.ts
@@ -112,4 +112,4 @@ export class Payment {
     purchasePromoCodeProductFlowUrl(code: string, state?: string, redirectUri?: string): string;
 }
 export default Payment;
-import RESTClient from "./RESTClient";
+import RESTClient from "./RESTClient.js";


### PR DESCRIPTION
When working with TypeScript set to handle NodeNext modules 
```json
  "compilerOptions": {
    "moduleResolution": "NodeNext",
    "module": "NodeNext",
```
There are compilation errors as below:
> TS2835: Relative import paths need explicit file extensions in EcmaScript imports when  --moduleResolution  is  node16  or  nodenext . Did you mean  ./SDKError.js ?