### PR TITLE
move navigation in hasSessionInProgress

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@schibsted/account-sdk-browser",
-  "version": "4.8.7-beta.3",
+  "version": "4.8.7-beta.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@schibsted/account-sdk-browser",
-      "version": "4.8.7-beta.3",
+      "version": "4.8.7-beta.4",
       "license": "MIT",
       "dependencies": {
         "tiny-emitter": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schibsted/account-sdk-browser",
-  "version": "4.8.7-beta.3",
+  "version": "4.8.7-beta.4",
   "description": "Schibsted account SDK for browsers",
   "main": "index.js",
   "type": "module",

--- a/src/identity.js
+++ b/src/identity.js
@@ -530,14 +530,12 @@ export class Identity extends EventEmitter {
                 throw err;
             }
 
-            if(sessionData){
+            if (sessionData){
                 // for expiring session and safari browser do full page redirect to gain new session
                 if(_checkRedirectionNeed(sessionData)){
                     await this.callbackBeforeRedirect();
 
-                    this.window.location.href = this._sessionService.makeUrl(sessionData.redirectURL);
-
-                    return;
+                    return this._sessionService.makeUrl(sessionData.redirectURL);
                 }
 
                 if (this._enableSessionCaching) {
@@ -552,6 +550,11 @@ export class Identity extends EventEmitter {
             .then(
                 sessionData => {
                     this._hasSessionInProgress = false;
+
+                    if (typeof sessionData === 'string' && isUrl(sessionData)) {
+                        return this.window.location.href = sessionData;
+                    }
+
                     return sessionData;
                 },
                 err => {

--- a/src/version.js
+++ b/src/version.js
@@ -1,5 +1,5 @@
 // Automatically generated in 'npm version' by scripts/genversion.js
 
 'use strict'
-const version = '4.8.7-beta.3';
+const version = '4.8.7-beta.4';
 export default version;


### PR DESCRIPTION
If brands are adding Identity calls in either callback or on page load lifecycle, calls can happen in parallel, leading to some calls taking place without the correct cookies and leading to user logout.

Moving navigation to hasSessionInProgress to  `getSession().then` seems to have fixed this problem