### PR TITLE
feat: add tabId to refresh-itp-cookies

### DIFF
--- a/__tests__/identity.js
+++ b/__tests__/identity.js
@@ -597,6 +597,10 @@ describe('Identity', () => {
             test('should do redirect when session endpoint respond with redirectURL only', async () => {
                 mockSessionOkResponse(Fixtures.sessionNeedsToBeRefreshedResponse)
 
+                const MOCK_TAB_ID = 1234;
+                const spy = jest.spyOn(Identity.prototype, '_getTabId');
+                spy.mockImplementation(() => MOCK_TAB_ID);
+
                 await identity.hasSession();
 
                 expect(defaultOptions.callbackBeforeRedirect).toHaveBeenCalled();
@@ -610,7 +614,9 @@ describe('Identity', () => {
                         '&redirect_uri=',
                         encodeURIComponent(defaultOptions.redirectUri),
                         '&sdk_version=',
-                        version
+                        version,
+                        '&tabId=',
+                        MOCK_TAB_ID
                     ].join('')
                 );
             });

--- a/src/identity.js
+++ b/src/identity.js
@@ -212,8 +212,6 @@ export class Identity extends EventEmitter {
         this._generateTabId();
     }
 
-    // pageload -> set cache -> redirect -> pageload
-
     /**
      * Generates browser tab ID if it's not present in cache
      * @private

--- a/src/identity.js
+++ b/src/identity.js
@@ -209,19 +209,6 @@ export class Identity extends EventEmitter {
         this._setGlobalSessionServiceUrl(env);
 
         this._unblockSessionCall();
-        this._generateTabId();
-    }
-
-    /**
-     * Generates browser tab ID if it's not present in cache
-     * @private
-     */
-    _generateTabId() {
-        if (this._enableSessionCaching) {
-            if (!this.cache.get(TAB_ID_KEY)) {
-                this.cache.set(TAB_ID_KEY, TAB_ID, TAB_ID_TTL)
-            }
-        }
     }
 
     /**
@@ -231,7 +218,13 @@ export class Identity extends EventEmitter {
      */
     _getTabId() {
         if (this._enableSessionCaching) {
-            return this.cache.get(TAB_ID_KEY)
+            const tabId = this.cache.get(TAB_ID_KEY);
+            if (!tabId) {
+                this.cache.set(TAB_ID_KEY, TAB_ID, TAB_ID_TTL);
+                return TAB_ID;
+            }
+
+            return tabId;
         }
     }
 


### PR DESCRIPTION
This PR adds a simple mechanism for creating tab-scoped IDs that are persistent after redirects.

Flow goes as follows:
page-load -> generate ID -> try to store ID in session storage if it's not present already -> session flow -> redirect -> read ID from session storage

We need this in order to debug a race condition bug causing logouts.
Tested locally using PRE env so logs confirm it works.