### PR TITLE
Rename cache instance and update dts

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -89,7 +89,6 @@ export default class Cache {
     /**
      * Get a value from cache (checks that the object has not expired)
      * @param {string} key
-     * @private
      * @returns {*} - The value if it exists, otherwise null
      */
     get(key) {
@@ -124,7 +123,6 @@ export default class Cache {
      * @param {string} key
      * @param {*} value
      * @param {Number} expiresIn - Value in milliseconds until the entry expires
-     * @private
      * @returns {void}
      */
     set(key, value, expiresIn = 0) {
@@ -145,7 +143,6 @@ export default class Cache {
     /**
      * Delete a cache entry
      * @param {string} key
-     * @private
      * @returns {void}
      */
     delete(key) {

--- a/src/cache.js
+++ b/src/cache.js
@@ -89,6 +89,7 @@ export default class Cache {
     /**
      * Get a value from cache (checks that the object has not expired)
      * @param {string} key
+     * @private
      * @returns {*} - The value if it exists, otherwise null
      */
     get(key) {
@@ -123,6 +124,7 @@ export default class Cache {
      * @param {string} key
      * @param {*} value
      * @param {Number} expiresIn - Value in milliseconds until the entry expires
+     * @private
      * @returns {void}
      */
     set(key, value, expiresIn = 0) {
@@ -143,6 +145,7 @@ export default class Cache {
     /**
      * Delete a cache entry
      * @param {string} key
+     * @private
      * @returns {void}
      */
     delete(key) {

--- a/src/identity.d.ts
+++ b/src/identity.d.ts
@@ -28,7 +28,8 @@ export class Identity extends TinyEmitter {
     _sessionInitiatedSent: boolean;
     window: any;
     clientId: string;
-    cache: any;
+    sessionStorageCache: any;
+    localStorageCache: any;
     redirectUri: string;
     env: string;
     log: Function;

--- a/src/identity.d.ts
+++ b/src/identity.d.ts
@@ -37,6 +37,34 @@ export class Identity extends TinyEmitter {
     _sessionDomain: string;
     _enableSessionCaching: boolean;
     _session: {};
+
+    /**
+     * Read tabId from session storage
+     * @returns {number}
+     * @private
+     */
+    private _getTabId;
+    /**
+     * Checks if getting session is blocked
+     * @private
+     *
+     * @returns {boolean|void}
+     */
+    private _isSessionCallBlocked;
+    /**
+     * Block calls to get session
+     * @private
+     *
+     * @returns {void}
+     */
+    private _blockSessionCall;
+    /**
+     * Unblocks calls to get session
+     * @private
+     *
+     * @returns {void}
+     */
+    private _unblockSessionCall;
     /**
      * Set SPiD server URL
      * @private

--- a/src/identity.js
+++ b/src/identity.js
@@ -219,9 +219,9 @@ export class Identity extends EventEmitter {
      */
     _getTabId() {
         if (this._enableSessionCaching) {
-            const tabId = this.cache.get(TAB_ID_KEY);
+            const tabId = this.sessionStorageCache.get(TAB_ID_KEY);
             if (!tabId) {
-                this.cache.set(TAB_ID_KEY, TAB_ID, TAB_ID_TTL);
+                this.sessionStorageCache.set(TAB_ID_KEY, TAB_ID, TAB_ID_TTL);
                 return TAB_ID;
             }
 
@@ -589,7 +589,7 @@ export class Identity extends EventEmitter {
             }
             let sessionData = null;
             try {
-                sessionData = await this._sessionService.get('/v2/session');
+                sessionData = await this._sessionService.get('/v2/session', {tabId: this._getTabId()});
             } catch (err) {
                 if (err && err.code === 400 && this._enableSessionCaching) {
                     const expiresIn = 1000 * (err.expiresIn || 300);


### PR DESCRIPTION
Fixes a bug regarding cache being no longer defined due to the split to localStorage and sessionStorage.
Additionally, adds missing methods to identity.d.ts