### PR TITLE
fix: delete sessionCallBlocked only by the same tab that added entry

### DIFF
--- a/__tests__/identity.js
+++ b/__tests__/identity.js
@@ -599,10 +599,7 @@ describe('Identity', () => {
                 const MOCK_TAB_ID = 1234;
                 const spy = jest.spyOn(Identity.prototype, '_getTabId');
                 spy.mockImplementation(() => MOCK_TAB_ID);
-
-                identity = new Identity(defaultOptions);
-                identity._sessionService.fetch = getSessionMock;
-                identity._clearVarnishCookie();
+                identity._tabId = MOCK_TAB_ID;
 
                 await identity.hasSession();
 

--- a/__tests__/identity.js
+++ b/__tests__/identity.js
@@ -563,7 +563,7 @@ describe('Identity', () => {
                 jest.spyOn(Date, 'now')
                     .mockReturnValue(new Date("2019-11-09T10:00:00").getTime());
 
-                const getExpiresOn = () => JSON.parse(identity.cache.cache.get('hasSession-cache')).expiresOn;
+                const getExpiresOn = () => JSON.parse(identity.sessionStorageCache.cache.get('hasSession-cache')).expiresOn;
 
                 await identity.hasSession();
 

--- a/__tests__/identity.js
+++ b/__tests__/identity.js
@@ -595,11 +595,14 @@ describe('Identity', () => {
 
         describe('session refresh full page redirect', ()=>{
             test('should do redirect when session endpoint respond with redirectURL only', async () => {
-                mockSessionOkResponse(Fixtures.sessionNeedsToBeRefreshedResponse)
-
+                mockSessionOkResponse(Fixtures.sessionNeedsToBeRefreshedResponse);
                 const MOCK_TAB_ID = 1234;
                 const spy = jest.spyOn(Identity.prototype, '_getTabId');
                 spy.mockImplementation(() => MOCK_TAB_ID);
+
+                identity = new Identity(defaultOptions);
+                identity._sessionService.fetch = getSessionMock;
+                identity._clearVarnishCookie();
 
                 await identity.hasSession();
 

--- a/src/cache.d.ts
+++ b/src/cache.d.ts
@@ -14,7 +14,6 @@ export default class Cache {
     /**
      * Get a value from cache (checks that the object has not expired)
      * @param {string} key
-     * @private
      * @returns {*} - The value if it exists, otherwise null
      */
     private get;
@@ -23,14 +22,12 @@ export default class Cache {
      * @param {string} key
      * @param {*} value
      * @param {Number} expiresIn - Value in milliseconds until the entry expires
-     * @private
      * @returns {void}
      */
     private set;
     /**
      * Delete a cache entry
      * @param {string} key
-     * @private
      * @returns {void}
      */
     private delete;

--- a/src/cache.js
+++ b/src/cache.js
@@ -89,7 +89,6 @@ export default class Cache {
     /**
      * Get a value from cache (checks that the object has not expired)
      * @param {string} key
-     * @private
      * @returns {*} - The value if it exists, otherwise null
      */
     get(key) {
@@ -124,7 +123,6 @@ export default class Cache {
      * @param {string} key
      * @param {*} value
      * @param {Number} expiresIn - Value in milliseconds until the entry expires
-     * @private
      * @returns {void}
      */
     set(key, value, expiresIn = 0) {
@@ -145,7 +143,6 @@ export default class Cache {
     /**
      * Delete a cache entry
      * @param {string} key
-     * @private
      * @returns {void}
      */
     delete(key) {

--- a/src/identity.d.ts
+++ b/src/identity.d.ts
@@ -44,23 +44,20 @@ export class Identity extends TinyEmitter {
      */
     private _getTabId;
     /**
-     * Checks if getting session is blocked
+     * Checks if calling get session is blocked
      * @private
-     *
      * @returns {boolean|void}
      */
     private _isSessionCallBlocked;
     /**
-     * Block calls to get session
+     * Block calls to get session. This is done to prevent concurrent calls which can log user out if session is refreshed by one of them
      * @private
-     *
      * @returns {void}
      */
     private _blockSessionCall;
     /**
-     * Unblocks calls to get session
+     * Unblocks calls to get session if the lock was put by the same tab
      * @private
-     *
      * @returns {void}
      */
     private _unblockSessionCall;
@@ -105,7 +102,7 @@ export class Identity extends TinyEmitter {
     private _setGlobalSessionServiceUrl;
     _globalSessionService: RESTClient;
     /**
-     * Emits the relevant events based on the previous and new reply from hassession
+     * Emits the relevant events based on the previous and new reply from {@link Identity#hasSession}
      * @private
      * @param {object} previous
      * @param {object} current
@@ -120,7 +117,7 @@ export class Identity extends TinyEmitter {
     private _closePopup;
     popup: Window;
     /**
-     * Set the Varnish cookie (`SP_ID`) when hasSession() is called. Note that most browsers require
+     * Set the Varnish cookie (`SP_ID`) when {@link Identity#hasSession} is called. Note that most browsers require
      * that you are on a "real domain" for this to work — so, **not** `localhost`
      * @param {object} [options]
      * @param {number} [options.expiresIn] Override this to set number of seconds before the varnish
@@ -223,7 +220,7 @@ export class Identity extends TinyEmitter {
      * @description This function calls {@link Identity#hasSession} internally and thus has the side
      * effect that it might perform an auto-login on the user
      * @throws {SDKError} If the user isn't connected to the merchant
-     * @return {Promise<string>} The `userId` field (not to be confused with the `uuid`)
+     * @return {number} The `userId` field (not to be confused with the `uuid`)
      */
     getUserId(): Promise<string>;
     /**
@@ -383,7 +380,7 @@ export type LoginOptions = {
      * `password` (will force password confirmation, even if user is already logged in), `eid`. Those values might
      * be mixed as space-separated string. To make sure that user has authenticated with 2FA you need
      * to verify AMR (Authentication Methods References) claim in ID token.
-     * Might also be used to ensure additional acr (sms, otp, eid) for already logged in users.
+     * Might also be used to ensure additional acr (sms, otp, eid) for already logged-in users.
      * Supported value is also 'otp-email' means one time password using email.
      */
     acrValues?: string;
@@ -452,7 +449,7 @@ export type SimplifiedLoginWidgetLoginOptions = {
      * `password` (will force password confirmation, even if user is already logged in). Those values might
      * be mixed as space-separated string. To make sure that user has authenticated with 2FA you need
      * to verify AMR (Authentication Methods References) claim in ID token.
-     * Might also be used to ensure additional acr (sms, otp) for already logged in users.
+     * Might also be used to ensure additional acr (sms, otp) for already logged-in users.
      * Supported value is also 'otp-email' means one time password using email.
      */
     acrValues?: string;
@@ -620,7 +617,7 @@ export type HasSessionFailureResponse = {
 };
 export type SimplifiedLoginData = {
     /**
-     * - Deprecated: User UUID, to be be used as `loginHint` for {@link Identity#login}
+     * - Deprecated: User UUID, to be used as `loginHint` for {@link Identity#login}
      */
     identifier: string;
     /**

--- a/src/identity.d.ts
+++ b/src/identity.d.ts
@@ -47,7 +47,7 @@ export class Identity extends TinyEmitter {
     /**
      * Checks if calling get session is blocked
      * @private
-     * @returns {boolean|void}
+     * @returns {string|null}
      */
     private _isSessionCallBlocked;
     /**

--- a/src/identity.d.ts
+++ b/src/identity.d.ts
@@ -45,8 +45,9 @@ export class Identity extends TinyEmitter {
      */
     private _getTabId;
     /**
-     * Checks if calling get session is blocked
+     * Checks if calling GET session is blocked by a cache storage
      * @private
+     * @param {Cache} cache - cache to check
      * @returns {string|null}
      */
     private _isSessionCallBlocked;
@@ -61,7 +62,7 @@ export class Identity extends TinyEmitter {
      * @private
      * @returns {void}
      */
-    private _unblockSessionCall;
+    private _unblockSessionCallByTab;
     /**
      * Set SPiD server URL
      * @private

--- a/src/identity.d.ts
+++ b/src/identity.d.ts
@@ -45,9 +45,8 @@ export class Identity extends TinyEmitter {
      */
     private _getTabId;
     /**
-     * Checks if calling GET session is blocked by a cache storage
+     * Checks if calling get session is blocked
      * @private
-     * @param {Cache} cache - cache to check
      * @returns {string|null}
      */
     private _isSessionCallBlocked;
@@ -62,7 +61,7 @@ export class Identity extends TinyEmitter {
      * @private
      * @returns {void}
      */
-    private _unblockSessionCallByTab;
+    private _unblockSessionCall;
     /**
      * Set SPiD server URL
      * @private

--- a/src/identity.js
+++ b/src/identity.js
@@ -674,12 +674,11 @@ export class Identity extends EventEmitter {
         this._hasSessionInProgress = _getSession()
             .then(
                 sessionData => {
-                    this._hasSessionInProgress = false;
-                    this._unblockSessionCallByTab();
-
                     if (isUrl(sessionData)) {
                         return this.window.location.href = sessionData;
                     }
+                    this._hasSessionInProgress = false;
+                    this._unblockSessionCallByTab();
 
                     return sessionData;
                 },

--- a/src/identity.js
+++ b/src/identity.js
@@ -146,7 +146,7 @@ import version from './version.js';
 
 const HAS_SESSION_CACHE_KEY = 'hasSession-cache';
 const SESSION_CALL_BLOCKED_CACHE_KEY = 'sessionCallBlocked-cache';
-const SESSION_CALL_BLOCKED_TTL = 1000 * 30; //set to 30s, the default period for a request timeout
+const SESSION_CALL_BLOCKED_TTL = 1000 * 15; //set to 15s, to not block calls much longer than the time attempting retries
 
 const TAB_ID_KEY = 'tab-id-cache';
 const TAB_ID = Math.floor(Math.random() * 100000)
@@ -213,7 +213,6 @@ export class Identity extends EventEmitter {
         this._setBffServerUrl(env);
         this._setOauthServerUrl(env);
         this._setGlobalSessionServiceUrl(env);
-        this._unblockSessionCallByTab();
     }
 
     /**
@@ -568,6 +567,7 @@ export class Identity extends EventEmitter {
             this._maybeSetVarnishCookie(sessionData);
             this._emitSessionEvent(this._session, sessionData);
             this._session = sessionData;
+
             return sessionData;
         };
 
@@ -611,7 +611,7 @@ export class Identity extends EventEmitter {
                         this.sessionStorageCache.set(HAS_SESSION_CACHE_KEY, sessionData, expiresIn);
                     }
 
-                    return _postProcess(sessionData)
+                    return _postProcess(sessionData);
                 }
             };
 

--- a/src/identity.js
+++ b/src/identity.js
@@ -180,7 +180,7 @@ export class Identity extends EventEmitter {
         env = 'PRE',
         log,
         window = globalWindow(),
-        callbackBeforeRedirect = ()=>{}
+        callbackBeforeRedirect = () => {}
     }) {
         super();
         assert(isNonEmptyString(clientId), 'clientId parameter is required');
@@ -197,7 +197,7 @@ export class Identity extends EventEmitter {
         this.window = window;
         this.clientId = clientId;
         this.sessionStorageCache = new Cache(() => this.window && this.window.sessionStorage);
-        this.localStorageCache = new Cache(() =>this.window && this.window.localStorage);
+        this.localStorageCache = new Cache(() => this.window && this.window.localStorage);
         this.redirectUri = redirectUri;
         this.env = env;
         this.log = log;
@@ -241,7 +241,7 @@ export class Identity extends EventEmitter {
      * @private
      * @returns {string|null}
      */
-    _isSessionCallBlocked(){
+    _isSessionCallBlocked() {
         return this.localStorageCache.get(SESSION_CALL_BLOCKED_CACHE_KEY);
     }
 
@@ -250,7 +250,7 @@ export class Identity extends EventEmitter {
      * @private
      * @returns {void}
      */
-    _blockSessionCall(){
+    _blockSessionCall() {
         this.localStorageCache.set(
             SESSION_CALL_BLOCKED_CACHE_KEY,
             this._tabId,
@@ -342,7 +342,7 @@ export class Identity extends EventEmitter {
         this._globalSessionService = new RESTClient({
             serverUrl: urlMapper(url, ENDPOINTS.SESSION_SERVICE),
             log: this.log,
-            defaultParams: { client_sdrn, sdk_version: version },
+            defaultParams: {client_sdrn, sdk_version: version},
         });
     }
 
@@ -506,7 +506,7 @@ export class Identity extends EventEmitter {
      * @returns {void}
      */
     _clearVarnishCookie() {
-        const baseDomain =  this._session && typeof this._session.baseDomain === 'string'
+        const baseDomain = this._session && typeof this._session.baseDomain === 'string'
             ? this._session.baseDomain
             : document.domain;
 
@@ -571,7 +571,7 @@ export class Identity extends EventEmitter {
             return sessionData;
         };
 
-        const _checkRedirectionNeed = (sessionData= {}) => {
+        const _checkRedirectionNeed = (sessionData = {}) => {
             const sessionDataKeys = Object.keys(sessionData);
 
             return sessionDataKeys.length === 1 &&
@@ -645,7 +645,7 @@ export class Identity extends EventEmitter {
                 return await useSessionResponseIfValid(sessionData);
             };
 
-            return await checkIfSessionCallIsNeededAndSafe(async ()=> {
+            return await checkIfSessionCallIsNeededAndSafe(async () => {
                 let retryCount = 0;
 
                 // Try to call session-service MAX_SESSION_CALL_RETRIES times, waiting up to 1 second each time
@@ -653,7 +653,7 @@ export class Identity extends EventEmitter {
                     retryCount++;
                     const randomWaitingStep = Math.floor(Math.random() * 9); // ignoring waiting times that are too small to matter
                     const randomWaitTime = MIN_SESSION_CALL_WAIT_TIME + (randomWaitingStep * 100);
-                    await new Promise( resolve => setTimeout(resolve, randomWaitTime));
+                    await new Promise(resolve => setTimeout(resolve, randomWaitTime));
 
                     // attempt to call session service, but don't take any action if call is blocked and don't use the result
                     const result = await checkIfSessionCallIsNeededAndSafe(null);
@@ -804,10 +804,10 @@ export class Identity extends EventEmitter {
         if (!pairId)
             throw new SDKError('pairId missing in user session!');
 
-        if(!externalParty || externalParty.length === 0) {
+        if (!externalParty || externalParty.length === 0) {
             throw new SDKError('externalParty cannot be empty');
         }
-        const _toHexDigest = (hashBuffer) =>{
+        const _toHexDigest = (hashBuffer) => {
             // Convert buffer to byte array
             const hashArray = Array.from(new Uint8Array(hashBuffer));
             // Convert bytes to hex string
@@ -886,6 +886,7 @@ export class Identity extends EventEmitter {
             return null;
         }
     }
+
     /**
      * If a popup is desired, this function needs to be called in response to a user event (like
      * click or tap) in order to work correctly. Otherwise the popup will be blocked by the
@@ -1136,7 +1137,10 @@ export class Identity extends EventEmitter {
                 };
 
                 const loginNotYouHandler = async () => {
-                    this.login(Object.assign(await prepareLoginParams(loginParams), {loginHint: userData.identifier, prompt: 'login'}));
+                    this.login(Object.assign(await prepareLoginParams(loginParams), {
+                        loginHint: userData.identifier,
+                        prompt: 'login'
+                    }));
                 };
 
                 const initHandler = () => {

--- a/src/identity.js
+++ b/src/identity.js
@@ -603,7 +603,7 @@ export class Identity extends EventEmitter {
                         await this.callbackBeforeRedirect();
 
                         // Doing a return here, to avoid caching the redirect response
-                        return this.window.location.href = this._sessionService.makeUrl(sessionData.redirectURL, {tabId: this._getTabId()});
+                        return this._sessionService.makeUrl(sessionData.redirectURL, {tabId: this._getTabId()});
                     }
 
                     if (this._enableSessionCaching) {
@@ -676,6 +676,10 @@ export class Identity extends EventEmitter {
                 sessionData => {
                     this._hasSessionInProgress = false;
                     this._unblockSessionCallByTab();
+
+                    if (isUrl(sessionData)) {
+                        return this.window.location.href = sessionData;
+                    }
 
                     return sessionData;
                 },

--- a/src/identity.js
+++ b/src/identity.js
@@ -193,8 +193,8 @@ export class Identity extends EventEmitter {
         this._sessionInitiatedSent = false;
         this.window = window;
         this.clientId = clientId;
-        this.sessionStorageCache = new Cache(this.window && this.window.sessionStorage);
-        this.localStorageCache = new Cache(this.window && this.window.localStorage);
+        this.sessionStorageCache = new Cache(() => this.window && this.window.sessionStorage);
+        this.localStorageCache = new Cache(() =>this.window && this.window.localStorage);
         this.redirectUri = redirectUri;
         this.env = env;
         this.log = log;

--- a/src/identity.js
+++ b/src/identity.js
@@ -26,7 +26,7 @@ import version from './version.js';
  * `password` (will force password confirmation, even if user is already logged in), `eid`. Those values might
  * be mixed as space-separated string. To make sure that user has authenticated with 2FA you need
  * to verify AMR (Authentication Methods References) claim in ID token.
- * Might also be used to ensure additional acr (sms, otp) for already logged in users.
+ * Might also be used to ensure additional acr (sms, otp) for already logged-in users.
  * Supported value is also 'otp-email' means one time password using email.
  * @property {string} [scope] - The OAuth scopes for the tokens. This is a list of
  * scopes, separated by space. If the list of scopes contains `openid`, the generated tokens
@@ -60,7 +60,7 @@ import version from './version.js';
  * `password` (will force password confirmation, even if user is already logged in). Those values might
  * be mixed as space-separated string. To make sure that user has authenticated with 2FA you need
  * to verify AMR (Authentication Methods References) claim in ID token.
- * Might also be used to ensure additional acr (sms, otp) for already logged in users.
+ * Might also be used to ensure additional acr (sms, otp) for already logged-in users.
  * Supported value is also 'otp-email' means one time password using email.
  * @property {string} [scope] - The OAuth scopes for the tokens. This is a list of
  * scopes, separated by space. If the list of scopes contains `openid`, the generated tokens
@@ -134,7 +134,7 @@ import version from './version.js';
 
 /**
  * @typedef {object} SimplifiedLoginData
- * @property {string} identifier - Deprecated: User UUID, to be be used as `loginHint` for {@link Identity#login}
+ * @property {string} identifier - Deprecated: User UUID, to be as `loginHint` for {@link Identity#login}
  * @property {string} display_text - Human-readable user identifier
  * @property {string} client_name - Client name
  */
@@ -155,7 +155,7 @@ const TAB_ID_TTL = 1000 * 60 * 60 * 24 * 30;
 const globalWindow = () => window;
 
 /**
- * Provides Identity functionalty to a web page
+ * Provides Identity functionality to a web page
  */
 export class Identity extends EventEmitter {
     /**
@@ -214,7 +214,7 @@ export class Identity extends EventEmitter {
     }
 
     /**
-     * Read tabId from session storage
+     * Read tabId from session storage if possible, otherwise save tabId to session storage and return it
      * @returns {number}
      * @private
      */
@@ -231,9 +231,8 @@ export class Identity extends EventEmitter {
     }
 
     /**
-     * Checks if getting session is blocked
+     * Checks if calling get session is blocked
      * @private
-     *
      * @returns {number|null}
      */
     _isSessionCallBlocked(){
@@ -241,9 +240,8 @@ export class Identity extends EventEmitter {
     }
 
     /**
-     * Block calls to get session
+     * Block calls to get session. This is done to prevent concurrent calls which can log user out if session is refreshed by one of them
      * @private
-     *
      * @returns {void}
      */
     _blockSessionCall(){
@@ -257,9 +255,8 @@ export class Identity extends EventEmitter {
     }
 
     /**
-     * Unblocks calls to get session
+     * Unblocks calls to get session if the lock was put by the same tab
      * @private
-     *
      * @returns {void}
      */
     _unblockSessionCallByTab() {
@@ -346,7 +343,7 @@ export class Identity extends EventEmitter {
     }
 
     /**
-     * Emits the relevant events based on the previous and new reply from hassession
+     * Emits the relevant events based on the previous and new reply from {@link Identity#hasSession}
      * @private
      * @param {object} previous
      * @param {object} current
@@ -426,7 +423,7 @@ export class Identity extends EventEmitter {
     }
 
     /**
-     * Set the Varnish cookie (`SP_ID`) when hasSession() is called. Note that most browsers require
+     * Set the Varnish cookie (`SP_ID`) when {@link Identity#hasSession} is called. Note that most browsers require
      * that you are on a "real domain" for this to work — so, **not** `localhost`
      * @param {object} [options]
      * @param {number} [options.expiresIn] Override this to set number of seconds before the varnish
@@ -715,7 +712,7 @@ export class Identity extends EventEmitter {
      * @description This function calls {@link Identity#hasSession} internally and thus has the side
      * effect that it might perform an auto-login on the user
      * @throws {SDKError} If the user isn't connected to the merchant
-     * @return {Promise<string>} The `userId` field (not to be confused with the `uuid`)
+     * @return {number} The `userId` field (not to be confused with the `uuid`)
      */
     async getUserId() {
         const user = await this.hasSession();

--- a/src/identity.js
+++ b/src/identity.js
@@ -586,8 +586,7 @@ export class Identity extends EventEmitter {
 
             // Prevent concurrent calls to session-service
             if (this._isSessionCallBlocked()) {
-                // Returning data directly, without _postProcess since the data returned is the local copy
-                return this._session;
+                return _postProcess(this._session);
             }
 
             let sessionData = null;
@@ -607,7 +606,7 @@ export class Identity extends EventEmitter {
                 // For expiring session and Safari browser do full page redirect to get new session
                 if(_checkRedirectionNeed(sessionData)){
                     await this.callbackBeforeRedirect();
-                    this.window.location.href = this._sessionService.makeUrl(sessionData.redirectURL, {tabId: this._getTabId()});
+                    return this.window.location.href = this._sessionService.makeUrl(sessionData.redirectURL, {tabId: this._getTabId()});
                 }
 
                 if (this._enableSessionCaching) {

--- a/src/identity.js
+++ b/src/identity.js
@@ -247,7 +247,7 @@ export class Identity extends EventEmitter {
     _blockSessionCall(){
         const SESSION_CALL_BLOCKED_BY_TAB = this._tabId;
 
-        this.cache.set(
+        this.localStorageCache.set(
             SESSION_CALL_BLOCKED_CACHE_KEY,
             SESSION_CALL_BLOCKED_BY_TAB,
             SESSION_CALL_BLOCKED_TTL
@@ -261,7 +261,7 @@ export class Identity extends EventEmitter {
      */
     _unblockSessionCallByTab() {
         if (this._isSessionCallBlocked() === this._tabId) {
-            this.cache.delete(SESSION_CALL_BLOCKED_CACHE_KEY);
+            this.localStorageCache.delete(SESSION_CALL_BLOCKED_CACHE_KEY);
         }
     }
 

--- a/src/identity.js
+++ b/src/identity.js
@@ -234,7 +234,7 @@ export class Identity extends EventEmitter {
      * Checks if getting session is blocked
      * @private
      *
-     * @returns {number}
+     * @returns {number/null}
      */
     _isSessionCallBlocked(){
         return this.localStorageCache.get(SESSION_CALL_BLOCKED_CACHE_KEY);

--- a/src/identity.js
+++ b/src/identity.js
@@ -146,7 +146,7 @@ import version from './version.js';
 
 const HAS_SESSION_CACHE_KEY = 'hasSession-cache';
 const SESSION_CALL_BLOCKED_CACHE_KEY = 'sessionCallBlocked-cache';
-const SESSION_CALL_BLOCKED_TTL = 1000 * 30;
+const SESSION_CALL_BLOCKED_TTL = 1000 * 30; //set to 30s, the default period for a request timeout
 
 const TAB_ID_KEY = 'tab-id-cache';
 const TAB_ID = Math.floor(Math.random() * 100000)
@@ -554,11 +554,6 @@ export class Identity extends EventEmitter {
      * @return {Promise<HasSessionSuccessResponse|HasSessionFailureResponse>}
      */
     hasSession() {
-        const isSessionCallBlocked = this._isSessionCallBlocked()
-        if (isSessionCallBlocked) {
-            return this._session;
-        }
-
         if (this._hasSessionInProgress) {
             return this._hasSessionInProgress;
         }
@@ -589,8 +584,16 @@ export class Identity extends EventEmitter {
                 }
             }
 
+            // Prevent concurrent calls to session-service
+            if (this._isSessionCallBlocked()) {
+                // Returning data directly, without _postProcess since the data returned is the local copy
+                return this._session;
+            }
+
             let sessionData = null;
             try {
+                this._blockSessionCall();
+
                 sessionData = await this._sessionService.get('/v2/session', {tabId: this._tabId});
             } catch (err) {
                 if (err && err.code === 400 && this._enableSessionCaching) {
@@ -601,13 +604,10 @@ export class Identity extends EventEmitter {
             }
 
             if (sessionData){
-                // for expiring session and safari browser do full page redirect to gain new session
+                // For expiring session and Safari browser do full page redirect to get new session
                 if(_checkRedirectionNeed(sessionData)){
-                    this._blockSessionCall();
-
                     await this.callbackBeforeRedirect();
-
-                    return this._sessionService.makeUrl(sessionData.redirectURL, {tabId: this._getTabId()});
+                    this.window.location.href = this._sessionService.makeUrl(sessionData.redirectURL, {tabId: this._getTabId()});
                 }
 
                 if (this._enableSessionCaching) {
@@ -623,10 +623,6 @@ export class Identity extends EventEmitter {
                 sessionData => {
                     this._hasSessionInProgress = false;
 
-                    if (isUrl(sessionData)) {
-                        return this.window.location.href = sessionData;
-                    }
-
                     return sessionData;
                 },
                 err => {
@@ -636,6 +632,7 @@ export class Identity extends EventEmitter {
                 }
             );
 
+        this._unblockSessionCallByTab();
         return this._hasSessionInProgress;
     }
 

--- a/src/identity.js
+++ b/src/identity.js
@@ -237,12 +237,13 @@ export class Identity extends EventEmitter {
     }
 
     /**
-     * Checks if calling GET session is blocked
+     * Checks if calling GET session is blocked by a cache storage
      * @private
+     * @param {Cache} cache - cache to check
      * @returns {string|null}
      */
-    _isSessionCallBlocked() {
-        return this.localStorageCache.get(SESSION_CALL_BLOCKED_CACHE_KEY);
+    _isSessionCallBlocked(cache) {
+        return cache.get(SESSION_CALL_BLOCKED_CACHE_KEY);
     }
 
     /**
@@ -251,6 +252,14 @@ export class Identity extends EventEmitter {
      * @returns {void}
      */
     _blockSessionCall() {
+        // session storage block protects against single tab, multiple identity instance concurrency
+        this.sessionStorageCache.set(
+            SESSION_CALL_BLOCKED_CACHE_KEY,
+            this._tabId,
+            SESSION_CALL_BLOCKED_TTL
+        );
+
+        // local storage block protects against cross-tab concurrency
         this.localStorageCache.set(
             SESSION_CALL_BLOCKED_CACHE_KEY,
             this._tabId,
@@ -264,9 +273,11 @@ export class Identity extends EventEmitter {
      * @returns {void}
      */
     _unblockSessionCallByTab() {
-        if (this._isSessionCallBlocked() === this._tabId) {
+        if (this._isSessionCallBlocked(this.localStorageCache) === this._tabId) {
             this.localStorageCache.delete(SESSION_CALL_BLOCKED_CACHE_KEY);
         }
+
+        this.sessionStorageCache.delete(SESSION_CALL_BLOCKED_CACHE_KEY);
     }
 
     /**
@@ -568,6 +579,7 @@ export class Identity extends EventEmitter {
             this._maybeSetVarnishCookie(sessionData);
             this._emitSessionEvent(this._session, sessionData);
             this._session = sessionData;
+
             return sessionData;
         };
 
@@ -611,7 +623,7 @@ export class Identity extends EventEmitter {
                         this.sessionStorageCache.set(HAS_SESSION_CACHE_KEY, sessionData, expiresIn);
                     }
 
-                    return _postProcess(sessionData)
+                    return _postProcess(sessionData);
                 }
             };
 
@@ -624,7 +636,7 @@ export class Identity extends EventEmitter {
                     }
                 }
 
-                if (this._isSessionCallBlocked()) {
+                if (this._isSessionCallBlocked(this.sessionStorageCache) || this._isSessionCallBlocked(this.localStorageCache)) {
                     if (this._session && this._session.userId) {
                         return _postProcess(this._session);
                     }
@@ -651,6 +663,7 @@ export class Identity extends EventEmitter {
                 // Try to call session-service MAX_SESSION_CALL_RETRIES times, waiting up to 1 second each time
                 while (retryCount < MAX_SESSION_CALL_RETRIES) {
                     retryCount++;
+
                     const randomWaitingStep = Math.floor(Math.random() * 9); // ignoring waiting times that are too small to matter
                     const randomWaitTime = MIN_SESSION_CALL_WAIT_TIME + (randomWaitingStep * 100);
                     await new Promise(resolve => setTimeout(resolve, randomWaitTime));


### PR DESCRIPTION
Currently, since local storage is shared between tabs, other tabs can clean session-service stop switch. Added logic to save tabId to `sessionCallBlocked-cache` instead of boolean value, and clean this entry only if tabId value matches