### PR TITLE
bug: fix on some calls path is not respected

### DIFF
--- a/src/identity.js
+++ b/src/identity.js
@@ -589,7 +589,7 @@ export class Identity extends EventEmitter {
             }
             let sessionData = null;
             try {
-                sessionData = await this._sessionService.get('/v2/session', {tabId: this._getTabId()});
+                sessionData = await this._sessionService.get('v2/session', {tabId: this._getTabId()});
             } catch (err) {
                 if (err && err.code === 400 && this._enableSessionCaching) {
                     const expiresIn = 1000 * (err.expiresIn || 300);
@@ -827,7 +827,7 @@ export class Identity extends EventEmitter {
      */
     async getUserContextData() {
         try {
-            return await this._globalSessionService.get('/user-context');
+            return await this._globalSessionService.get('user-context');
         } catch (_) {
             return null;
         }


### PR DESCRIPTION
ref: UUI-2540

In 2 instances of calls, RESTClient methods were called, which in turn ended up using `new URL()`. Because these calls were done starting with `/`, the domain path was ignored, resulting in possible wrong URLs for the calls.