### PR TITLE
feat(): add created instances exposed as standard window properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,13 +83,13 @@ Events are emitted for:
 
 | Class | event name |
 |--- | --- |
-| Identity | `sch_identity:init` |
-| Monetization | `sch_monetization:init` |
-| Payment | `sch_payment:init` |
+| Identity | `schIdentity:ready` |
+| Monetization | `schMonetization:ready` |
+| Payment | `schPayment:ready` |
 
 ```js
-document.addEventListener('sch_identity:init', e => {
-    // The event contains the initialized instancese.detail.instance);
+document.addEventListener('schIdentity:ready', e => {
+    // The event contains the initialized instance (e.detail.instance);
 }
 
 ```

--- a/README.md
+++ b/README.md
@@ -61,12 +61,13 @@ You can use that code as inspiration or just fork and play with it. The account-
 module is used for authenticating the user with Schibsted account. Take a look at how the SDK is
 initialized.
 
-When a user wants to log in to your site, you direct them to a UI flow hosted by **Schibsted Account**.
-We authenticate the user and redirect them back to your site. This final redirect back to your site is performed in accordance with the OAuth2 specification.
+When a user wants to log in to your site, you direct them to a UI flow hosted by **Schibsted Account**. 
+We authenticate the user and redirect them back to your site. This final redirect back to your site is performed in accordance with the OAuth2 specification. 
 This means we pass a `code` in the query string of that redirect URI.
-You can use that `code` on your site's backend, along with your client credentials (client ID and secret), to obtain an _Access Token_ (AT) and a _Refresh Token_ (RT).
-You should not send the AT (and **never** the RT!) to the browser. Instead, keep them on the server side and associate them with the specific user session.
+You can use that `code` on your site's backend, along with your client credentials (client ID and secret), to obtain an *Access Token* (AT) and a *Refresh Token* (RT). 
+You should not send the AT (and **never** the RT!) to the browser. Instead, keep them on the server side and associate them with the specific user session. 
 This allows you to call Schibsted Account APIs on behalf of that user.
+
 
 ## Events
 
@@ -78,20 +79,17 @@ methods are `.on(eventName, listener)` (to subscribe to an event) and `.off(even
 (to unsubscribe to an event).
 
 The SDK also emits global events on the `document` when a new instance is created.
-Events are emitted for
+Events are emitted for: 
 
-| Class        | event name              |
-| ------------ | ----------------------- |
-| Identity     | `sch_identity:init`     |
+| Class | event name |
+|--- | --- |
+| Identity | `sch_identity:init` |
 | Monetization | `sch_monetization:init` |
-| Payment      | `sch_payment:init`      |
-
-Example:
+| Payment | `sch_payment:init` |
 
 ```js
 document.addEventListener('sch_identity:init', e => {
-    // The event contains the initialized instances as
-    // e.detail.instance;
+    // The event contains the initialized instancese.detail.instance);
 }
 
 ```
@@ -103,29 +101,29 @@ Let's start with a bit of example code:
 #### Example
 
 ```javascript
-import { Identity } from "@schibsted/account-sdk-browser";
+import { Identity } from '@schibsted/account-sdk-browser'
 
 const identity = new Identity({
-    clientId: "56e9a5d1eee0000000000000",
-    redirectUri: "https://awesomenews.site", // ensure it's listed in selfservice
-    env: "PRE", // Schibsted account env. A url or a special key: 'PRE', 'PRO', 'PRO_NO', 'PRO_FI' or 'PRO_DK'
-    sessionDomain: "https://id.awesomenews.site", // client-configured session-service domain
-});
+    clientId: '56e9a5d1eee0000000000000',
+    redirectUri: 'https://awesomenews.site', // ensure it's listed in selfservice
+    env: 'PRE', // Schibsted account env. A url or a special key: 'PRE', 'PRO', 'PRO_NO', 'PRO_FI' or 'PRO_DK'
+    sessionDomain: 'https://id.awesomenews.site', // client-configured session-service domain
+})
 
 async function whenSiteLoaded() {
-    const loginContainer = document.getElementById("login-container");
+    const loginContainer = document.getElementById('login-container')
     if (await identity.isLoggedIn()) {
-        const user = await identity.getUser();
-        const span = document.createElement("span");
-        span.textContent = `Hello ${user.givenName}`;
-        loginContainer.appendChild(span);
+        const user = await identity.getUser()
+        const span = document.createElement('span')
+        span.textContent = `Hello ${user.givenName}`
+        loginContainer.appendChild(span)
     } else {
-        loginContainer.innerHTML = '<button class="login-button">Log in</button>';
+        loginContainer.innerHTML = '<button class="login-button">Log in</button>'
     }
 }
 
 function userClicksLogIn() {
-    identity.login({ state: "some-random-string-1234-foobar-wonky-pig" });
+    identity.login({ state: 'some-random-string-1234-foobar-wonky-pig' })
 }
 ```
 
@@ -144,11 +142,10 @@ with the auth `code` parameter.
 
 It is recommended that you provide a unique identifier as part of the state, to prevent CSRF
 attacks. For example this can be accomplished by:
-
 1. Your backend generates random token: `1234abcd`, saves it in some tokenCache, and forwards to
    your browser frontend
 1. Your frontend calls `Identity.login` with `state = base64Urlencode({ token: '1234abcd', article:
-'1234', ... })`
+   '1234', ... })`
 1. When auth flow completes, the user is redirected back to your site. Then, your backend sees the
    query parameters `code` (which it can exchange for OAuth tokens for the user) and `state`
 1. Your backend can do `decodedState = base64Urldecode(query.state)` and then verify that its
@@ -161,23 +158,22 @@ attacks. For example this can be accomplished by:
 Although Schibsted account abstracts away the details of how the users sign up or log in, it's worth
 mentioning that your end users have a few ways to log in:
 
--   Username & password: pretty self-explanatory; users register using an email address and a
-    self-chosen password
--   Passwordless - email: here, the users enter their email address and receive a one-time code that
-    they can use to log in
--   Multifactor authentication: first client indicates which methods should be preferred, later these
-    will be included (if fulfilled) in `AMR` claim of IDToken
+* Username & password: pretty self-explanatory; users register using an email address and a
+  self-chosen password
+* Passwordless - email: here, the users enter their email address and receive a one-time code that
+  they can use to log in
+* Multifactor authentication: first client indicates which methods should be preferred, later these
+  will be included (if fulfilled) in `AMR` claim of IDToken
 
 The default is username & password. If you wish to use one of the passwordless login methods, the
 `login()` function takes an optional parameter called `acrValues` (Authentication Context Class Reference).
 The `acrValues` parameter with multifactor authentication can take following values:
-
--   `eid` - authentication using BankID (for DEV and PRE environments you can choose between country specific solution by specifying `eid-no` or `eid-se` instead)
--   `otp-email` - passwordless authentication using code sent to registered email
--   `password` - force password authentication (even if user is already logged in)
--   `otp` - authentication using registered one time code generator (https://tools.ietf.org/html/rfc6238)
--   `sms` - authentication using SMS code sent to phone number
--   `password otp sms` - those authentication methods might be combined
+ - `eid` - authentication using BankID (for DEV and PRE environments you can choose between country specific solution by specifying `eid-no` or `eid-se` instead)
+ - `otp-email` - passwordless authentication using code sent to registered email
+ - `password` - force password authentication (even if user is already logged in)
+ - `otp` - authentication using registered one time code generator (https://tools.ietf.org/html/rfc6238)
+ - `sms` - authentication using SMS code sent to phone number
+ - `password otp sms` - those authentication methods might be combined
 
 The classic way to authenticate a user, is to send them from your site to the Schibsted account
 domain, let the user authenticate there, and then have us redirect them back to your site. If you
@@ -196,15 +192,15 @@ Schibsted account relies on browser cookies to determine whether a user is recog
 The SDK provides functions that can be used to check if the user that's visiting your site is
 already a Schibsted user or not.
 
--   [Identity#isLoggedIn](https://schibsted.github.io/account-sdk-browser/Identity.html#isLoggedIn)
-    tells you if the user that is visiting your site is already logged in to Schibsted account or not.
--   [Identity#isConnected](https://schibsted.github.io/account-sdk-browser/Identity.html#isConnected)
-    tells you if the user is connected to your client. A user might have `isLoggedIn=true` and at the
-    same time `isConnected=false` if they have logged in to Schibsted account, but not accepted terms
-    and privacy policy for your site.
+* [Identity#isLoggedIn](https://schibsted.github.io/account-sdk-browser/Identity.html#isLoggedIn)
+  tells you if the user that is visiting your site is already logged in to Schibsted account or not.
+* [Identity#isConnected](https://schibsted.github.io/account-sdk-browser/Identity.html#isConnected)
+  tells you if the user is connected to your client. A user might have `isLoggedIn=true` and at the
+  same time `isConnected=false` if they have logged in to Schibsted account, but not accepted terms
+  and privacy policy for your site.
 
 If you've lately changed your terms & conditions, maybe the user still hasn't accepted them. In that
-case they are considered _not connected_. In that case, if they click "Log in" from your site, we
+case they are considered *not connected*. In that case, if they click "Log in" from your site, we
 will just ask them to accept those terms and redirect them right back to your site.
 
 #### Logging out
@@ -221,24 +217,23 @@ It requires using Session Service, and supports both Schibsted account productId
 feature id's.
 
 #### Example
-
 ```javascript
-import { Monetization } from "@schibsted/account-sdk-browser";
+import { Monetization } from '@schibsted/account-sdk-browser'
 
 const monetization = new Monetization({
-    clientId: "56e9a5d1eee0000000000000",
-    redirectUri: "https://awesomenews.site", // ensure it's listed in selfservice
-    sessionDomain: "https://id.aweseome.site", // client-configured session-service domain
-    env: "PRE", // Schibsted account env. A url or a special key: 'PRE', 'PRO' or 'PRO_NO'
+    clientId: '56e9a5d1eee0000000000000',
+    redirectUri: 'https://awesomenews.site', // ensure it's listed in selfservice
+    sessionDomain: 'https://id.aweseome.site', // client-configured session-service domain
+    env: 'PRE', // Schibsted account env. A url or a special key: 'PRE', 'PRO' or 'PRO_NO'
 });
 
 try {
     // Check if the user has access to a a particular product
     const userId = await identity.getUserId();
     const data = await monetization.hasAccess([productId], userId);
-    alert(`User has access to ${productId}? ${data.entitled}`);
+    alert(`User has access to ${productId}? ${data.entitled}`)
 } catch (err) {
-    alert(`Could not query if the user has access to ${productId} because ${err}`);
+    alert(`Could not query if the user has access to ${productId} because ${err}`)
 }
 ```
 
@@ -250,20 +245,20 @@ pages for redeeming voucher codes, reviewing payment history, and more.
 #### Example
 
 ```javascript
-import { Payment } from "@schibsted/account-sdk-browser";
+import { Payment } from '@schibsted/account-sdk-browser'
 
 const paymentSDK = new Payment({
-    clientId: "56e9a5d1eee0000000000000",
-    redirectUri: "https://awesomenews.site", // ensure it's listed in selfservice
-    env: "PRE", // Schibsted account env. A url or a special key: 'PRE', 'PRO' or 'PRO_NO'
-});
+    clientId: '56e9a5d1eee0000000000000',
+    redirectUri: 'https://awesomenews.site', // ensure it's listed in selfservice
+    env: 'PRE', // Schibsted account env. A url or a special key: 'PRE', 'PRO' or 'PRO_NO'
+})
 
 // Get the url to paymentSDK with paylink
-const paylink = "...";
-const paylinkUrl = paymentSDK.purchasePaylinkUrl(paylink);
+const paylink = '...'
+const paylinkUrl = paymentSDK.purchasePaylinkUrl(paylink)
 
 // Or another example --- pay with paylink in a popup
-paymentSDK.payWithPaylink(paylink);
+paymentSDK.payWithPaylink(paylink)
 ```
 
 ## Appendix
@@ -294,28 +289,27 @@ browser side. Nevertheless, here is a short description of them.
    production environments is `vgs_email`, because reasons (on PRE, it is called `spid-pre-data`).
    It's a JSON string that's encoded using the standard `encodeURIComponent()` function and is an
    object that contains two pieces of information that's important:
-    - `remember`: if set to `true`, the user chose to be remembered and this means we usually support
-      auto-login (that is, if you call the Schibsted account hassession service, and no session can
-      be found in the session database, it will automatically create a new one for the user so that
-      they don't have to authenticate again. If it is `false`, it should be interpreted as the user
-      does not want to be automatically logged in to any site when their session expires
-    - `v`: the version number
+   * `remember`: if set to `true`, the user chose to be remembered and this means we usually support
+     auto-login (that is, if you call the Schibsted account hassession service, and no session can
+     be found in the session database, it will automatically create a new one for the user so that
+     they don't have to authenticate again. If it is `false`, it should be interpreted as the user
+     does not want to be automatically logged in to any site when their session expires
+   * `v`: the version number
 1. The **session** cookies: Cookie names in production environments are `identity`, and `SPID_SE` or
    `SPID_NO`. It contains:
-    - `user`: an object (if it's missing, a call to hassession will return a `401` with a
-      `UserException` that says `No session found`)
-        - `userId` identifies the user. We use this property to compare "old" user with "new" user and
-          fire events that indicate that the user has changed
-        - `is_logged_in` indicates if the user is logged in
-    - `user_tags`: a map that contains some flags about the user; namely:
-        - `is_logged_in` indicates if the user is logged in (this seems to be a duplicate of a
-          property with a similar name in the parent `user` object)
-        - `terms`: a map of term ids that indicate if they've been accepted by the user.
-    - `referer` (yep, missing the double "rr"..): If this is missing, a call to hassession will
-      return a `401` with a `UserException` that says `No session found`.
+   * `user`: an object (if it's missing, a call to hassession will return a `401` with a
+     `UserException` that says `No session found`)
+     * `userId` identifies the user. We use this property to compare "old" user with "new" user and
+       fire events that indicate that the user has changed
+     * `is_logged_in` indicates if the user is logged in
+   * `user_tags`: a map that contains some flags about the user; namely:
+     * `is_logged_in` indicates if the user is logged in (this seems to be a duplicate of a
+       property with a similar name in the parent `user` object)
+     * `terms`: a map of term ids that indicate if they've been accepted by the user.
+   * `referer` (yep, missing the double "rr"..): If this is missing, a call to hassession will
+     return a `401` with a `UserException` that says `No session found`.
 
 ## Releasing
-
 Tags are pushed to NPM via Travis. To release a new version, run in master
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ initialized.
 When a user wants to log in to your site, you direct them to a UI flow hosted by **Schibsted Account**.
 We authenticate the user and redirect them back to your site. This final redirect back to your site is performed in accordance with the OAuth2 specification.
 This means we pass a `code` in the query string of that redirect URI.
-You can use that `code` on your site's backend, along with your client credentials (client ID and secret), to obtain an _Access Token_ (AT) and a _Refresh Token_ (RT).
+You can use that `code` on your site's backend, along with your client credentials (client ID and secret), to obtain an *Access Token* (AT) and a *Refresh Token* (RT).
 You should not send the AT (and **never** the RT!) to the browser. Instead, keep them on the server side and associate them with the specific user session.
 This allows you to call Schibsted Account APIs on behalf of that user.
 
@@ -100,20 +100,20 @@ Let's start with a bit of example code:
 #### Example
 
 ```javascript
-import { Identity } from "@schibsted/account-sdk-browser";
+import { Identity } from '@schibsted/account-sdk-browser';
 
 const identity = new Identity({
-    clientId: "56e9a5d1eee0000000000000",
-    redirectUri: "https://awesomenews.site", // ensure it's listed in selfservice
-    env: "PRE", // Schibsted account env. A url or a special key: 'PRE', 'PRO', 'PRO_NO', 'PRO_FI' or 'PRO_DK'
-    sessionDomain: "https://id.awesomenews.site", // client-configured session-service domain
+    clientId: '56e9a5d1eee0000000000000',
+    redirectUri: 'https://awesomenews.site', // ensure it's listed in selfservice
+    env: 'PRE', // Schibsted account env. A url or a special key: 'PRE', 'PRO', 'PRO_NO', 'PRO_FI' or 'PRO_DK'
+    sessionDomain: 'https://id.awesomenews.site', // client-configured session-service domain
 });
 
 async function whenSiteLoaded() {
-    const loginContainer = document.getElementById("login-container");
+    const loginContainer = document.getElementById('login-container');
     if (await identity.isLoggedIn()) {
         const user = await identity.getUser();
-        const span = document.createElement("span");
+        const span = document.createElement('span');
         span.textContent = `Hello ${user.givenName}`;
         loginContainer.appendChild(span);
     } else {
@@ -122,7 +122,7 @@ async function whenSiteLoaded() {
 }
 
 function userClicksLogIn() {
-    identity.login({ state: "some-random-string-1234-foobar-wonky-pig" });
+    identity.login({ state: 'some-random-string-1234-foobar-wonky-pig' });
 }
 ```
 
@@ -158,23 +158,23 @@ attacks. For example this can be accomplished by:
 Although Schibsted account abstracts away the details of how the users sign up or log in, it's worth
 mentioning that your end users have a few ways to log in:
 
--   Username & password: pretty self-explanatory; users register using an email address and a
+ Username & password: pretty self-explanatory; users register using an email address and a
     self-chosen password
--   Passwordless - email: here, the users enter their email address and receive a one-time code that
+*  Passwordless - email: here, the users enter their email address and receive a one-time code that
     they can use to log in
--   Multifactor authentication: first client indicates which methods should be preferred, later these
+*  Multifactor authentication: first client indicates which methods should be preferred, later these
     will be included (if fulfilled) in `AMR` claim of IDToken
 
 The default is username & password. If you wish to use one of the passwordless login methods, the
 `login()` function takes an optional parameter called `acrValues` (Authentication Context Class Reference).
 The `acrValues` parameter with multifactor authentication can take following values:
 
--   `eid` - authentication using BankID (for DEV and PRE environments you can choose between country specific solution by specifying `eid-no` or `eid-se` instead)
--   `otp-email` - passwordless authentication using code sent to registered email
--   `password` - force password authentication (even if user is already logged in)
--   `otp` - authentication using registered one time code generator (https://tools.ietf.org/html/rfc6238)
--   `sms` - authentication using SMS code sent to phone number
--   `password otp sms` - those authentication methods might be combined
+*  `eid` - authentication using BankID (for DEV and PRE environments you can choose between country specific solution by specifying `eid-no` or `eid-se` instead)
+*  `otp-email` - passwordless authentication using code sent to registered email
+*  `password` - force password authentication (even if user is already logged in)
+*  `otp` - authentication using registered one time code generator (https://tools.ietf.org/html/rfc6238)
+*  `sms` - authentication using SMS code sent to phone number
+*  `password otp sms` - those authentication methods might be combined
 
 The classic way to authenticate a user, is to send them from your site to the Schibsted account
 domain, let the user authenticate there, and then have us redirect them back to your site. If you
@@ -193,15 +193,16 @@ Schibsted account relies on browser cookies to determine whether a user is recog
 The SDK provides functions that can be used to check if the user that's visiting your site is
 already a Schibsted user or not.
 
--   [Identity#isLoggedIn](https://schibsted.github.io/account-sdk-browser/Identity.html#isLoggedIn)
+*  [Identity#isLoggedIn](https://schibsted.github.io/account-sdk-browser/Identity.html#isLoggedIn)
     tells you if the user that is visiting your site is already logged in to Schibsted account or not.
--   [Identity#isConnected](https://schibsted.github.io/account-sdk-browser/Identity.html#isConnected)
+
+*  [Identity#isConnected](https://schibsted.github.io/account-sdk-browser/Identity.html#isConnected)
     tells you if the user is connected to your client. A user might have `isLoggedIn=true` and at the
     same time `isConnected=false` if they have logged in to Schibsted account, but not accepted terms
     and privacy policy for your site.
 
 If you've lately changed your terms & conditions, maybe the user still hasn't accepted them. In that
-case they are considered _not connected_. In that case, if they click "Log in" from your site, we
+case they are considered *not connected*. In that case, if they click "Log in" from your site, we
 will just ask them to accept those terms and redirect them right back to your site.
 
 #### Logging out
@@ -220,13 +221,13 @@ feature id's.
 #### Example
 
 ```javascript
-import { Monetization } from "@schibsted/account-sdk-browser";
+import { Monetization } from '@schibsted/account-sdk-browser';
 
 const monetization = new Monetization({
-    clientId: "56e9a5d1eee0000000000000",
-    redirectUri: "https://awesomenews.site", // ensure it's listed in selfservice
-    sessionDomain: "https://id.aweseome.site", // client-configured session-service domain
-    env: "PRE", // Schibsted account env. A url or a special key: 'PRE', 'PRO' or 'PRO_NO'
+    clientId: '56e9a5d1eee0000000000000',
+    redirectUri: 'https://awesomenews.site', // ensure it's listed in selfservice
+    sessionDomain: 'https://id.aweseome.site', // client-configured session-service domain
+    env: 'PRE', // Schibsted account env. A url or a special key: 'PRE', 'PRO' or 'PRO_NO'
 });
 
 try {
@@ -247,16 +248,16 @@ pages for redeeming voucher codes, reviewing payment history, and more.
 #### Example
 
 ```javascript
-import { Payment } from "@schibsted/account-sdk-browser";
+import { Payment } from '@schibsted/account-sdk-browser';
 
 const paymentSDK = new Payment({
-    clientId: "56e9a5d1eee0000000000000",
-    redirectUri: "https://awesomenews.site", // ensure it's listed in selfservice
-    env: "PRE", // Schibsted account env. A url or a special key: 'PRE', 'PRO' or 'PRO_NO'
+    clientId: '56e9a5d1eee0000000000000',
+    redirectUri: 'https://awesomenews.site', // ensure it's listed in selfservice
+    env: 'PRE', // Schibsted account env. A url or a special key: 'PRE', 'PRO' or 'PRO_NO'
 });
 
 // Get the url to paymentSDK with paylink
-const paylink = "...";
+const paylink = '...';
 const paylinkUrl = paymentSDK.purchasePaylinkUrl(paylink);
 
 // Or another example --- pay with paylink in a popup

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ attacks. For example this can be accomplished by:
 Although Schibsted account abstracts away the details of how the users sign up or log in, it's worth
 mentioning that your end users have a few ways to log in:
 
- Username & password: pretty self-explanatory; users register using an email address and a
+* Username & password: pretty self-explanatory; users register using an email address and a
     self-chosen password
 *  Passwordless - email: here, the users enter their email address and receive a one-time code that
     they can use to log in
@@ -292,24 +292,24 @@ browser side. Nevertheless, here is a short description of them.
    production environments is `vgs_email`, because reasons (on PRE, it is called `spid-pre-data`).
    It's a JSON string that's encoded using the standard `encodeURIComponent()` function and is an
    object that contains two pieces of information that's important:
-    - `remember`: if set to `true`, the user chose to be remembered and this means we usually support
+    * `remember`: if set to `true`, the user chose to be remembered and this means we usually support
       auto-login (that is, if you call the Schibsted account hassession service, and no session can
       be found in the session database, it will automatically create a new one for the user so that
       they don't have to authenticate again. If it is `false`, it should be interpreted as the user
       does not want to be automatically logged in to any site when their session expires
-    - `v`: the version number
+    * `v`: the version number
 1. The **session** cookies: Cookie names in production environments are `identity`, and `SPID_SE` or
    `SPID_NO`. It contains:
-    - `user`: an object (if it's missing, a call to hassession will return a `401` with a
+    * `user`: an object (if it's missing, a call to hassession will return a `401` with a
       `UserException` that says `No session found`)
-        - `userId` identifies the user. We use this property to compare "old" user with "new" user and
+        * `userId` identifies the user. We use this property to compare "old" user with "new" user and
           fire events that indicate that the user has changed
-        - `is_logged_in` indicates if the user is logged in
-    - `user_tags`: a map that contains some flags about the user; namely:
-        - `is_logged_in` indicates if the user is logged in (this seems to be a duplicate of a
+        * `is_logged_in` indicates if the user is logged in
+    * `user_tags`: a map that contains some flags about the user; namely:
+        * `is_logged_in` indicates if the user is logged in (this seems to be a duplicate of a
           property with a similar name in the parent `user` object)
-        - `terms`: a map of term ids that indicate if they've been accepted by the user.
-    - `referer` (yep, missing the double "rr"..): If this is missing, a call to hassession will
+        * `terms`: a map of term ids that indicate if they've been accepted by the user.
+    * `referer` (yep, missing the double "rr"..): If this is missing, a call to hassession will
       return a `401` with a `UserException` that says `No session found`.
 
 ## Releasing

--- a/README.md
+++ b/README.md
@@ -61,22 +61,40 @@ You can use that code as inspiration or just fork and play with it. The account-
 module is used for authenticating the user with Schibsted account. Take a look at how the SDK is
 initialized.
 
-When a user wants to log in to your site, you direct them to a UI flow hosted by **Schibsted Account**. 
-We authenticate the user and redirect them back to your site. This final redirect back to your site is performed in accordance with the OAuth2 specification. 
+When a user wants to log in to your site, you direct them to a UI flow hosted by **Schibsted Account**.
+We authenticate the user and redirect them back to your site. This final redirect back to your site is performed in accordance with the OAuth2 specification.
 This means we pass a `code` in the query string of that redirect URI.
-You can use that `code` on your site's backend, along with your client credentials (client ID and secret), to obtain an *Access Token* (AT) and a *Refresh Token* (RT). 
-You should not send the AT (and **never** the RT!) to the browser. Instead, keep them on the server side and associate them with the specific user session. 
+You can use that `code` on your site's backend, along with your client credentials (client ID and secret), to obtain an _Access Token_ (AT) and a _Refresh Token_ (RT).
+You should not send the AT (and **never** the RT!) to the browser. Instead, keep them on the server side and associate them with the specific user session.
 This allows you to call Schibsted Account APIs on behalf of that user.
-
 
 ## Events
 
-The SDK fires events when something we deem interesting is happening. For example the
+The SDK fires events on the instances when something we deem interesting is happening. For example the
 [Identity](https://schibsted.github.io/account-sdk-browser/Identity.html) class
 emits some events when the user is logged in or logged out. This SDK uses a familar interface that's
 very similar to Node's [EventEmitter](https://nodejs.org/api/events.html). The most important
 methods are `.on(eventName, listener)` (to subscribe to an event) and `.off(eventName, listener)`
 (to unsubscribe to an event).
+
+The SDK also emits global events on the `document` when a new instance is created.
+Events are emitted for
+
+| Class        | event name              |
+| ------------ | ----------------------- |
+| Identity     | `sch_identity:init`     |
+| Monetization | `sch_monetization:init` |
+| Payment      | `sch_payment:init`      |
+
+Example:
+
+```js
+document.addEventListener('sch_identity:init', e => {
+    // The event contains the initialized instances as
+    // e.detail.instance;
+}
+
+```
 
 ## Identity
 
@@ -85,29 +103,29 @@ Let's start with a bit of example code:
 #### Example
 
 ```javascript
-import { Identity } from '@schibsted/account-sdk-browser'
+import { Identity } from "@schibsted/account-sdk-browser";
 
 const identity = new Identity({
-    clientId: '56e9a5d1eee0000000000000',
-    redirectUri: 'https://awesomenews.site', // ensure it's listed in selfservice
-    env: 'PRE', // Schibsted account env. A url or a special key: 'PRE', 'PRO', 'PRO_NO', 'PRO_FI' or 'PRO_DK'
-    sessionDomain: 'https://id.awesomenews.site', // client-configured session-service domain
-})
+    clientId: "56e9a5d1eee0000000000000",
+    redirectUri: "https://awesomenews.site", // ensure it's listed in selfservice
+    env: "PRE", // Schibsted account env. A url or a special key: 'PRE', 'PRO', 'PRO_NO', 'PRO_FI' or 'PRO_DK'
+    sessionDomain: "https://id.awesomenews.site", // client-configured session-service domain
+});
 
 async function whenSiteLoaded() {
-    const loginContainer = document.getElementById('login-container')
+    const loginContainer = document.getElementById("login-container");
     if (await identity.isLoggedIn()) {
-        const user = await identity.getUser()
-        const span = document.createElement('span')
-        span.textContent = `Hello ${user.givenName}`
-        loginContainer.appendChild(span)
+        const user = await identity.getUser();
+        const span = document.createElement("span");
+        span.textContent = `Hello ${user.givenName}`;
+        loginContainer.appendChild(span);
     } else {
-        loginContainer.innerHTML = '<button class="login-button">Log in</button>'
+        loginContainer.innerHTML = '<button class="login-button">Log in</button>';
     }
 }
 
 function userClicksLogIn() {
-    identity.login({ state: 'some-random-string-1234-foobar-wonky-pig' })
+    identity.login({ state: "some-random-string-1234-foobar-wonky-pig" });
 }
 ```
 
@@ -126,10 +144,11 @@ with the auth `code` parameter.
 
 It is recommended that you provide a unique identifier as part of the state, to prevent CSRF
 attacks. For example this can be accomplished by:
+
 1. Your backend generates random token: `1234abcd`, saves it in some tokenCache, and forwards to
    your browser frontend
 1. Your frontend calls `Identity.login` with `state = base64Urlencode({ token: '1234abcd', article:
-   '1234', ... })`
+'1234', ... })`
 1. When auth flow completes, the user is redirected back to your site. Then, your backend sees the
    query parameters `code` (which it can exchange for OAuth tokens for the user) and `state`
 1. Your backend can do `decodedState = base64Urldecode(query.state)` and then verify that its
@@ -142,22 +161,23 @@ attacks. For example this can be accomplished by:
 Although Schibsted account abstracts away the details of how the users sign up or log in, it's worth
 mentioning that your end users have a few ways to log in:
 
-* Username & password: pretty self-explanatory; users register using an email address and a
-  self-chosen password
-* Passwordless - email: here, the users enter their email address and receive a one-time code that
-  they can use to log in
-* Multifactor authentication: first client indicates which methods should be preferred, later these
-  will be included (if fulfilled) in `AMR` claim of IDToken
+-   Username & password: pretty self-explanatory; users register using an email address and a
+    self-chosen password
+-   Passwordless - email: here, the users enter their email address and receive a one-time code that
+    they can use to log in
+-   Multifactor authentication: first client indicates which methods should be preferred, later these
+    will be included (if fulfilled) in `AMR` claim of IDToken
 
 The default is username & password. If you wish to use one of the passwordless login methods, the
 `login()` function takes an optional parameter called `acrValues` (Authentication Context Class Reference).
 The `acrValues` parameter with multifactor authentication can take following values:
- - `eid` - authentication using BankID (for DEV and PRE environments you can choose between country specific solution by specifying `eid-no` or `eid-se` instead)
- - `otp-email` - passwordless authentication using code sent to registered email
- - `password` - force password authentication (even if user is already logged in)
- - `otp` - authentication using registered one time code generator (https://tools.ietf.org/html/rfc6238)
- - `sms` - authentication using SMS code sent to phone number
- - `password otp sms` - those authentication methods might be combined
+
+-   `eid` - authentication using BankID (for DEV and PRE environments you can choose between country specific solution by specifying `eid-no` or `eid-se` instead)
+-   `otp-email` - passwordless authentication using code sent to registered email
+-   `password` - force password authentication (even if user is already logged in)
+-   `otp` - authentication using registered one time code generator (https://tools.ietf.org/html/rfc6238)
+-   `sms` - authentication using SMS code sent to phone number
+-   `password otp sms` - those authentication methods might be combined
 
 The classic way to authenticate a user, is to send them from your site to the Schibsted account
 domain, let the user authenticate there, and then have us redirect them back to your site. If you
@@ -176,15 +196,15 @@ Schibsted account relies on browser cookies to determine whether a user is recog
 The SDK provides functions that can be used to check if the user that's visiting your site is
 already a Schibsted user or not.
 
-* [Identity#isLoggedIn](https://schibsted.github.io/account-sdk-browser/Identity.html#isLoggedIn)
-  tells you if the user that is visiting your site is already logged in to Schibsted account or not.
-* [Identity#isConnected](https://schibsted.github.io/account-sdk-browser/Identity.html#isConnected)
-  tells you if the user is connected to your client. A user might have `isLoggedIn=true` and at the
-  same time `isConnected=false` if they have logged in to Schibsted account, but not accepted terms
-  and privacy policy for your site.
+-   [Identity#isLoggedIn](https://schibsted.github.io/account-sdk-browser/Identity.html#isLoggedIn)
+    tells you if the user that is visiting your site is already logged in to Schibsted account or not.
+-   [Identity#isConnected](https://schibsted.github.io/account-sdk-browser/Identity.html#isConnected)
+    tells you if the user is connected to your client. A user might have `isLoggedIn=true` and at the
+    same time `isConnected=false` if they have logged in to Schibsted account, but not accepted terms
+    and privacy policy for your site.
 
 If you've lately changed your terms & conditions, maybe the user still hasn't accepted them. In that
-case they are considered *not connected*. In that case, if they click "Log in" from your site, we
+case they are considered _not connected_. In that case, if they click "Log in" from your site, we
 will just ask them to accept those terms and redirect them right back to your site.
 
 #### Logging out
@@ -201,23 +221,24 @@ It requires using Session Service, and supports both Schibsted account productId
 feature id's.
 
 #### Example
+
 ```javascript
-import { Monetization } from '@schibsted/account-sdk-browser'
+import { Monetization } from "@schibsted/account-sdk-browser";
 
 const monetization = new Monetization({
-    clientId: '56e9a5d1eee0000000000000',
-    redirectUri: 'https://awesomenews.site', // ensure it's listed in selfservice
-    sessionDomain: 'https://id.aweseome.site', // client-configured session-service domain
-    env: 'PRE', // Schibsted account env. A url or a special key: 'PRE', 'PRO' or 'PRO_NO'
+    clientId: "56e9a5d1eee0000000000000",
+    redirectUri: "https://awesomenews.site", // ensure it's listed in selfservice
+    sessionDomain: "https://id.aweseome.site", // client-configured session-service domain
+    env: "PRE", // Schibsted account env. A url or a special key: 'PRE', 'PRO' or 'PRO_NO'
 });
 
 try {
     // Check if the user has access to a a particular product
     const userId = await identity.getUserId();
     const data = await monetization.hasAccess([productId], userId);
-    alert(`User has access to ${productId}? ${data.entitled}`)
+    alert(`User has access to ${productId}? ${data.entitled}`);
 } catch (err) {
-    alert(`Could not query if the user has access to ${productId} because ${err}`)
+    alert(`Could not query if the user has access to ${productId} because ${err}`);
 }
 ```
 
@@ -229,20 +250,20 @@ pages for redeeming voucher codes, reviewing payment history, and more.
 #### Example
 
 ```javascript
-import { Payment } from '@schibsted/account-sdk-browser'
+import { Payment } from "@schibsted/account-sdk-browser";
 
 const paymentSDK = new Payment({
-    clientId: '56e9a5d1eee0000000000000',
-    redirectUri: 'https://awesomenews.site', // ensure it's listed in selfservice
-    env: 'PRE', // Schibsted account env. A url or a special key: 'PRE', 'PRO' or 'PRO_NO'
-})
+    clientId: "56e9a5d1eee0000000000000",
+    redirectUri: "https://awesomenews.site", // ensure it's listed in selfservice
+    env: "PRE", // Schibsted account env. A url or a special key: 'PRE', 'PRO' or 'PRO_NO'
+});
 
 // Get the url to paymentSDK with paylink
-const paylink = '...'
-const paylinkUrl = paymentSDK.purchasePaylinkUrl(paylink)
+const paylink = "...";
+const paylinkUrl = paymentSDK.purchasePaylinkUrl(paylink);
 
 // Or another example --- pay with paylink in a popup
-paymentSDK.payWithPaylink(paylink)
+paymentSDK.payWithPaylink(paylink);
 ```
 
 ## Appendix
@@ -273,27 +294,28 @@ browser side. Nevertheless, here is a short description of them.
    production environments is `vgs_email`, because reasons (on PRE, it is called `spid-pre-data`).
    It's a JSON string that's encoded using the standard `encodeURIComponent()` function and is an
    object that contains two pieces of information that's important:
-   * `remember`: if set to `true`, the user chose to be remembered and this means we usually support
-     auto-login (that is, if you call the Schibsted account hassession service, and no session can
-     be found in the session database, it will automatically create a new one for the user so that
-     they don't have to authenticate again. If it is `false`, it should be interpreted as the user
-     does not want to be automatically logged in to any site when their session expires
-   * `v`: the version number
+    - `remember`: if set to `true`, the user chose to be remembered and this means we usually support
+      auto-login (that is, if you call the Schibsted account hassession service, and no session can
+      be found in the session database, it will automatically create a new one for the user so that
+      they don't have to authenticate again. If it is `false`, it should be interpreted as the user
+      does not want to be automatically logged in to any site when their session expires
+    - `v`: the version number
 1. The **session** cookies: Cookie names in production environments are `identity`, and `SPID_SE` or
    `SPID_NO`. It contains:
-   * `user`: an object (if it's missing, a call to hassession will return a `401` with a
-     `UserException` that says `No session found`)
-     * `userId` identifies the user. We use this property to compare "old" user with "new" user and
-       fire events that indicate that the user has changed
-     * `is_logged_in` indicates if the user is logged in
-   * `user_tags`: a map that contains some flags about the user; namely:
-     * `is_logged_in` indicates if the user is logged in (this seems to be a duplicate of a
-       property with a similar name in the parent `user` object)
-     * `terms`: a map of term ids that indicate if they've been accepted by the user.
-   * `referer` (yep, missing the double "rr"..): If this is missing, a call to hassession will
-     return a `401` with a `UserException` that says `No session found`.
+    - `user`: an object (if it's missing, a call to hassession will return a `401` with a
+      `UserException` that says `No session found`)
+        - `userId` identifies the user. We use this property to compare "old" user with "new" user and
+          fire events that indicate that the user has changed
+        - `is_logged_in` indicates if the user is logged in
+    - `user_tags`: a map that contains some flags about the user; namely:
+        - `is_logged_in` indicates if the user is logged in (this seems to be a duplicate of a
+          property with a similar name in the parent `user` object)
+        - `terms`: a map of term ids that indicate if they've been accepted by the user.
+    - `referer` (yep, missing the double "rr"..): If this is missing, a call to hassession will
+      return a `401` with a `UserException` that says `No session found`.
 
 ## Releasing
+
 Tags are pushed to NPM via Travis. To release a new version, run in master
 
 ```bash

--- a/__tests__/identity.js
+++ b/__tests__/identity.js
@@ -1592,21 +1592,20 @@ describe('Identity', () => {
 
     describe('global registration', () => {
         test('should register as window.schIdentity', () => {
-            const window = { location: {}};
+            const window = { location: {} };
             const instance = new Identity(Object.assign({}, defaultOptions, { window }));
 
             expect(window.schIdentity).toBe(instance);
         })
-        test('should emit document event', async () => {
-            const window = { location: {}};
-            const event = new Promise(resolve => {
-                window.addEventListener('schIdentity:init', e => {
-                    resolve(e);
-                });
-            });
+        test('should emit window event', async () => {
+            const window = { location: {}, dispatchEvent: jest.fn() };
+
             const instance = new Identity(Object.assign({}, defaultOptions, { window }));
 
-            expect(event).resolves.toMatchObject({ detail: { instance } });
+            expect(window.dispatchEvent).toHaveBeenCalledWith(expect.objectContaining({
+                type: 'schIdentity:ready',
+                detail: { instance }
+            }));
         })
     });
 });

--- a/__tests__/identity.js
+++ b/__tests__/identity.js
@@ -1600,7 +1600,7 @@ describe('Identity', () => {
         test('should emit document event', async () => {
             const window = { location: {}};
             const event = new Promise(resolve => {
-                document.addEventListener('schIdentity:init', e => {
+                window.addEventListener('schIdentity:init', e => {
                     resolve(e);
                 });
             });

--- a/__tests__/identity.js
+++ b/__tests__/identity.js
@@ -1589,4 +1589,24 @@ describe('Identity', () => {
             window.console = console;
         })
     })
+
+    describe('global registration', () => {
+        test('should register as window.sch_identity', () => {
+            const window = { location: {}};
+            const instance = new Identity(Object.assign({}, defaultOptions, { window }));
+
+            expect(window.sch_identity).toBe(instance);
+        })
+        test('should emit document event', async () => {
+            const window = { location: {}};
+            const event = new Promise(resolve => {
+                document.addEventListener('sch_identity:init', e => {
+                    resolve(e);
+                });
+            });
+            const instance = new Identity(Object.assign({}, defaultOptions, { window }));
+
+            expect(event).resolves.toMatchObject({ detail: { instance } });
+        })
+    });
 });

--- a/__tests__/identity.js
+++ b/__tests__/identity.js
@@ -1591,16 +1591,16 @@ describe('Identity', () => {
     })
 
     describe('global registration', () => {
-        test('should register as window.sch_identity', () => {
+        test('should register as window.schIdentity', () => {
             const window = { location: {}};
             const instance = new Identity(Object.assign({}, defaultOptions, { window }));
 
-            expect(window.sch_identity).toBe(instance);
+            expect(window.schIdentity).toBe(instance);
         })
         test('should emit document event', async () => {
             const window = { location: {}};
             const event = new Promise(resolve => {
-                document.addEventListener('sch_identity:init', e => {
+                document.addEventListener('schIdentity:init', e => {
                     resolve(e);
                 });
             });

--- a/__tests__/monetization.js
+++ b/__tests__/monetization.js
@@ -146,16 +146,16 @@ describe('Monetization', () => {
     });
 
     describe('global registration', () => {
-        test('registers itself as window.sch_monetization', () => {
+        test('registers itself as window.schMonetization', () => {
 
             const window = {};
             const instance = new Monetization({ clientId: 'a', window });
-            expect(window.sch_monetization).toBe(instance);
+            expect(window.schMonetization).toBe(instance);
         })
         test('emits document event', async () => {
 
             const event = new Promise(resolve => {
-                document.addEventListener('sch_monetization:init', e => {
+                document.addEventListener('schMonetization:init', e => {
                     resolve(e);
                 });
             });

--- a/__tests__/monetization.js
+++ b/__tests__/monetization.js
@@ -144,4 +144,23 @@ describe('Monetization', () => {
             expect(url).toBe('https://identity-pre.schibsted.com/account/products?client_id=a&redirect_uri=http%3A%2F%2Ffoo.bar');
         });
     });
+
+    describe('global registration', () => {
+        test('registers itself as window.sch_monetization', () => {
+
+            const window = {};
+            const instance = new Monetization({ clientId: 'a', window });
+            expect(window.sch_monetization).toBe(instance);
+        })
+        test('emits document event', async () => {
+
+            const event = new Promise(resolve => {
+                document.addEventListener('sch_monetization:init', e => {
+                    resolve(e);
+                });
+            });
+            const instance = new Monetization({ clientId: 'a'});
+            expect(event).resolves.toMatchObject({ detail: { instance } });
+        })
+    });
 });

--- a/__tests__/monetization.js
+++ b/__tests__/monetization.js
@@ -152,15 +152,15 @@ describe('Monetization', () => {
             const instance = new Monetization({ clientId: 'a', window });
             expect(window.schMonetization).toBe(instance);
         })
-        test('emits document event', async () => {
+        test('emits window event', async () => {
 
-            const event = new Promise(resolve => {
-                window.addEventListener('schMonetization:init', e => {
-                    resolve(e);
-                });
-            });
-            const instance = new Monetization({ clientId: 'a'});
-            expect(event).resolves.toMatchObject({ detail: { instance } });
+            const window = { location: {}, dispatchEvent: jest.fn() };
+            const instance = new Monetization({ clientId: 'a', window });
+            expect(window.dispatchEvent).toHaveBeenCalledTimes(1);
+            expect(window.dispatchEvent).toHaveBeenCalledWith(expect.objectContaining({
+                type: 'schMonetization:ready',
+                detail: { instance }
+            }));
         })
     });
 });

--- a/__tests__/monetization.js
+++ b/__tests__/monetization.js
@@ -155,7 +155,7 @@ describe('Monetization', () => {
         test('emits document event', async () => {
 
             const event = new Promise(resolve => {
-                document.addEventListener('schMonetization:init', e => {
+                window.addEventListener('schMonetization:init', e => {
                     resolve(e);
                 });
             });

--- a/__tests__/payment.js
+++ b/__tests__/payment.js
@@ -244,4 +244,23 @@ describe('Payment', () => {
             );
         });
     });
+
+    describe('global registration', () => {
+        test('registers itself as window.sch_payment', () => {
+            const window = { location: {}};
+            const instance = new Payment({ clientId: 'a',  window });
+            expect(window.sch_payment).toBe(instance);
+        })
+
+        test('emits document event', async () => {
+            const window = { location: {}};
+            const event = new Promise(resolve => {
+                document.addEventListener('sch_payment:init', e => {
+                    resolve(e);
+                });
+            });
+            const instance = new Payment({ clientId: 'a', window });
+            expect(event).resolves.toMatchObject({ detail: { instance } });
+        })
+    });
 });

--- a/__tests__/payment.js
+++ b/__tests__/payment.js
@@ -247,20 +247,20 @@ describe('Payment', () => {
 
     describe('global registration', () => {
         test('registers itself as window.schPayment', () => {
-            const window = { location: {}};
-            const instance = new Payment({ clientId: 'a',  window });
+
+            const window = { location: {}, dispatchEvent: jest.fn() };
+            const instance = new Payment({ clientId: 'a', window });
             expect(window.schPayment).toBe(instance);
         })
 
-        test('emits document event', async () => {
-            const window = { location: {}};
-            const event = new Promise(resolve => {
-                window.addEventListener('schPayment:init', e => {
-                    resolve(e);
-                });
-            });
+        test('emits window event', async () => {
+            const window = { location: {}, dispatchEvent: jest.fn() };
+
             const instance = new Payment({ clientId: 'a', window });
-            expect(event).resolves.toMatchObject({ detail: { instance } });
+            expect(window.dispatchEvent).toHaveBeenCalledWith(expect.objectContaining({
+                type: 'schPayment:ready',
+                detail: { instance }
+            }));
         })
     });
 });

--- a/__tests__/payment.js
+++ b/__tests__/payment.js
@@ -246,16 +246,16 @@ describe('Payment', () => {
     });
 
     describe('global registration', () => {
-        test('registers itself as window.sch_payment', () => {
+        test('registers itself as window.schPayment', () => {
             const window = { location: {}};
             const instance = new Payment({ clientId: 'a',  window });
-            expect(window.sch_payment).toBe(instance);
+            expect(window.schPayment).toBe(instance);
         })
 
         test('emits document event', async () => {
             const window = { location: {}};
             const event = new Promise(resolve => {
-                document.addEventListener('sch_payment:init', e => {
+                document.addEventListener('schPayment:init', e => {
                     resolve(e);
                 });
             });

--- a/__tests__/payment.js
+++ b/__tests__/payment.js
@@ -255,7 +255,7 @@ describe('Payment', () => {
         test('emits document event', async () => {
             const window = { location: {}};
             const event = new Promise(resolve => {
-                document.addEventListener('schPayment:init', e => {
+                window.addEventListener('schPayment:init', e => {
                     resolve(e);
                 });
             });

--- a/src/global-registry.js
+++ b/src/global-registry.js
@@ -13,6 +13,6 @@ export const registerGlobal = (global, componentClassName, instance) => {
     if (!(global)[prefixedName]) {
         (global)[prefixedName] = instance;
     }
-    document.dispatchEvent(new CustomEvent(`${prefixedName}:ready`, { detail: { instance } }));
+    window.dispatchEvent(new CustomEvent(`${prefixedName}:ready`, { detail: { instance } }));
 }
 

--- a/src/global-registry.js
+++ b/src/global-registry.js
@@ -1,18 +1,18 @@
 
 /**
  * Registers a component as a property on the provided global object, if not already registered, and dispatches an event to notify listeners.
- * The event is dispatched on `document` and will have the name `$sch_${componentName}:init` and a `detail` property with the instance.
+ * The event is dispatched on `document` and will have the name `$sch${componentClassName}:ready` and a `detail` property with the instance.
  *
  * @param {any} global typically `window`
- * @param {string} componentName the name of the component to register, 'identity', 'monetization' or 'payment'
+ * @param {string} componentClassName the name of the component to register, 'identity', 'monetization' or 'payment'
  * @param {any} instance the instance of the component to register
  * @returns {void}
  */
-export const registerGlobal = (global, componentName, instance) => {
-    const prefixedName = `sch_${componentName}`;
+export const registerGlobal = (global, componentClassName, instance) => {
+    const prefixedName = `sch${componentClassName}`;
     if (!(global)[prefixedName]) {
         (global)[prefixedName] = instance;
     }
-    document.dispatchEvent(new CustomEvent(`${prefixedName}:init`, { detail: { instance } }));
+    document.dispatchEvent(new CustomEvent(`${prefixedName}:ready`, { detail: { instance } }));
 }
 

--- a/src/global-registry.js
+++ b/src/global-registry.js
@@ -1,0 +1,18 @@
+
+/**
+ * Registers a component globally if not already registered, and dispatches an event to notify listeners.
+ * The event is dispatched on `document` and will have the name `$sch_${componentName}:init` and a `detail` property with the instance.
+ *
+ * @param {any} global typically `window`
+ * @param {string} componentName the name of the component to register
+ * @param {any} instance the instance of the component to register
+ * @returns {void}
+ */
+export const registerGlobal = (global, componentName, instance) => {
+    const prefixedName = `sch_${componentName}`;
+    if (!(global)[prefixedName]) {
+        (global)[prefixedName] = instance;
+    }
+    document.dispatchEvent(new CustomEvent(`${prefixedName}:init`, { detail: { instance } }));
+}
+

--- a/src/global-registry.js
+++ b/src/global-registry.js
@@ -13,6 +13,8 @@ export const registerGlobal = (global, componentClassName, instance) => {
     if (!(global)[prefixedName]) {
         (global)[prefixedName] = instance;
     }
-    window.dispatchEvent(new CustomEvent(`${prefixedName}:ready`, { detail: { instance } }));
+    if (typeof global.dispatchEvent === 'function') {
+        global.dispatchEvent(new CustomEvent(`${prefixedName}:ready`, { detail: { instance } }));
+    }
 }
 

--- a/src/global-registry.js
+++ b/src/global-registry.js
@@ -1,10 +1,10 @@
 
 /**
- * Registers a component globally if not already registered, and dispatches an event to notify listeners.
+ * Registers a component as a property on the provided global object, if not already registered, and dispatches an event to notify listeners.
  * The event is dispatched on `document` and will have the name `$sch_${componentName}:init` and a `detail` property with the instance.
  *
  * @param {any} global typically `window`
- * @param {string} componentName the name of the component to register
+ * @param {string} componentName the name of the component to register, 'identity', 'monetization' or 'payment'
  * @param {any} instance the instance of the component to register
  * @returns {void}
  */

--- a/src/identity.js
+++ b/src/identity.js
@@ -220,7 +220,7 @@ export class Identity extends EventEmitter {
 
         this._unblockSessionCall();
 
-        registerGlobal(window, 'identity', this);
+        registerGlobal(window, 'Identity', this);
 
     }
 

--- a/src/identity.js
+++ b/src/identity.js
@@ -15,6 +15,7 @@ import RESTClient from './RESTClient.js';
 import SDKError from './SDKError.js';
 import * as spidTalk from './spidTalk.js';
 import version from './version.js';
+import { registerGlobal } from './global-registry.js';
 
 /**
  * @typedef {object} LoginOptions
@@ -218,6 +219,9 @@ export class Identity extends EventEmitter {
         this._setGlobalSessionServiceUrl(env);
 
         this._unblockSessionCall();
+
+        registerGlobal(window, 'identity', this);
+
     }
 
     /**

--- a/src/monetization.js
+++ b/src/monetization.js
@@ -13,6 +13,7 @@ import Cache from './cache.js';
 import * as spidTalk from './spidTalk.js';
 import SDKError from './SDKError.js';
 import version from './version.js';
+import { registerGlobal } from './global-registry.js';
 
 const globalWindow = () => window;
 
@@ -45,6 +46,7 @@ export class Monetization extends EventEmitter {
             assert(isUrl(sessionDomain), 'sessionDomain parameter is not a valid URL');
             this._setSessionServiceUrl(sessionDomain);
         }
+        registerGlobal(window, 'monetization', this);
     }
 
     /**

--- a/src/monetization.js
+++ b/src/monetization.js
@@ -46,7 +46,7 @@ export class Monetization extends EventEmitter {
             assert(isUrl(sessionDomain), 'sessionDomain parameter is not a valid URL');
             this._setSessionServiceUrl(sessionDomain);
         }
-        registerGlobal(window, 'monetization', this);
+        registerGlobal(window, 'Monetization', this);
     }
 
     /**

--- a/src/payment.js
+++ b/src/payment.js
@@ -10,6 +10,7 @@ import { ENDPOINTS } from './config.js';
 import * as popup from './popup.js';
 import RESTClient from './RESTClient.js';
 import * as spidTalk from './spidTalk.js';
+import { registerGlobal } from './global-registry.js';
 
 const globalWindow = () => window;
 
@@ -37,6 +38,7 @@ export class Payment {
         this.publisher = publisher;
         this._setSpidServerUrl(env);
         this._setBffServerUrl(env);
+        registerGlobal(window, 'payment', this);
     }
 
     /**

--- a/src/payment.js
+++ b/src/payment.js
@@ -38,7 +38,7 @@ export class Payment {
         this.publisher = publisher;
         this._setSpidServerUrl(env);
         this._setBffServerUrl(env);
-        registerGlobal(window, 'payment', this);
+        registerGlobal(window, 'Payment', this);
     }
 
     /**


### PR DESCRIPTION
# Background
A LOT of components in Schibsted depend on an instance of the Account SDK being passed to it.
Until now there is no standardised way to either access an instance or reliably wait until an instance exists.

This has lead to similar code repeating itself in multiple places, with subtle differences and sometimes errors.

Example exports from [vg/frimand](https://schibsted.ghe.com/vg/frimand/blob/fd5c688af8bfd3edb6ef9a73f9636b7f4a3b9039/resources/js/auth/schibsted-account.js#L31) 
```ts
// Better safe than sorry
// Initializing and assigning to mulitiple global properties, to satisfy all dependees
window.SPiD_Identity = new Identity(config);
window.Identity = window.SPiD_Identity;
```
Another example from [@schibsted/sourcepoint](https://schibsted.ghe.com/privacy/sourcepoint/blob/master/src/browser/schibsted-account/index.js), where additional complexity has been added because different brands expose the `Identity` instance differently
```ts
// This code would essentially be redundant if we had a standard
const defaultIdentityObjectName = 'Identity';

export function getIdentityObject(_window, config) {
    if (_window.psi?.identityObject) return _window.psi.identityObject;
    if (config?.identityObject) return config.identityObject;

    const windowIdentity = _window.psi?.identityObjectName || config?.identityObjectName || defaultIdentityObjectName;

    if (!_window[windowIdentity]) {
        return console.warn('No Schibsted Account integration detected.');
    }

    return _window[windowIdentity];
};

```
# Proposed change 
The change proposed in this PR is for the SDK classes (`Identity`, `Monetization` and `Payment`) to automatically 

1. expose the instance created as a standard property on the  `window` object
2. emit an event when an instance is created (and made available on the `window` property)

With this proposed change, client code can over time become simpler and components will be easier to integrate seamlessly with the Account sdk. A standard, reliable and loosely coupled dependency on the Identity SDK could now look like:

```ts
async function resolveIdentityInstance() {
	return new Promise((resolve) => {
		if (window.schIdentity) {
			resolve(window.schIdentity);
		} else {
			document.addEventListener('schIdentity:ready', () => {
				resolve(window.schIdentity);
			}
		}
	});
}

const sdk = await resolveIdentityInstance();
```

# See also 
See also, similar request for the Pulse SDK: https://schibsted.ghe.com/data-platform/pulse-sdk-js/issues/120