### PR TITLE
feat: Request coalescing for concurrent Monetization.hasAccess calls

### DIFF
--- a/__tests__/monetization.js
+++ b/__tests__/monetization.js
@@ -116,6 +116,7 @@ describe('Monetization', () => {
 
                 expect(mon._sessionService.go.mock.calls.length).toBe(1);
             });
+
             test('should call session service once for each productId', async () => {
                 const promises = [
                     mon.hasAccess(['existing'], 12345),
@@ -126,6 +127,7 @@ describe('Monetization', () => {
 
                 expect(mon._sessionService.go.mock.calls.length).toBe(2);
             });
+
             test('should call session service once for each userId', async () => {
                 const promises = [
                     mon.hasAccess(['existing'], 12345),

--- a/__tests__/monetization.js
+++ b/__tests__/monetization.js
@@ -105,6 +105,37 @@ describe('Monetization', () => {
 
             expect(mon._sessionService.go.mock.calls.length).toBe(2);
         });
+
+        describe('concurrent calls', () => {
+            test('should only call session service once for same productIds and userId', async () => {
+                const promises = [
+                    mon.hasAccess(['existing'], 12345),
+                    mon.hasAccess(['existing'], 12345),
+                ];
+                await Promise.all(promises);
+
+                expect(mon._sessionService.go.mock.calls.length).toBe(1);
+            });
+            test('should call session service once for each productId', async () => {
+                const promises = [
+                    mon.hasAccess(['existing'], 12345),
+                    mon.hasAccess(['non_existing'], 12345),
+                    mon
+                ];
+                await Promise.all(promises);
+
+                expect(mon._sessionService.go.mock.calls.length).toBe(2);
+            });
+            test('should call session service once for each userId', async () => {
+                const promises = [
+                    mon.hasAccess(['existing'], 12345),
+                    mon.hasAccess(['existing'], 67890),
+                ];
+                await Promise.all(promises);
+
+                expect(mon._sessionService.go.mock.calls.length).toBe(2);
+            });
+        });
     });
 
     describe('productsUrl', () => {

--- a/src/monetization.js
+++ b/src/monetization.js
@@ -100,8 +100,8 @@ export class Monetization extends EventEmitter {
             throw new SDKError(`'productIds' must be an array`);
         }
 
-        const sortedIds = productIds.sort();
-        const cacheKey = this._accessCacheKey(productIds, userId);
+        const sortedIds = [...productIds].sort();
+        const cacheKey = this._accessCacheKey(sortedIds, userId);
         let data = this.cache.get(cacheKey);
         if (!data) {
             if (!this.pendingHasAccessRequests[cacheKey]) {
@@ -142,7 +142,7 @@ export class Monetization extends EventEmitter {
      * @private
      */
     _accessCacheKey(productIds, userId) {
-        return `prd_${productIds.sort()}_${userId}`;
+        return `prd_${[...productIds].sort()}_${userId}`;
     }
 
     /**

--- a/src/monetization.js
+++ b/src/monetization.js
@@ -40,6 +40,7 @@ export class Monetization extends EventEmitter {
         this.clientId = clientId;
         this.env = env;
         this.redirectUri = redirectUri;
+        this.pendingHasAccessRequests = {};
         this._setSpidServerUrl(env);
 
         if (sessionDomain) {
@@ -103,7 +104,15 @@ export class Monetization extends EventEmitter {
         const cacheKey = this._accessCacheKey(productIds, userId);
         let data = this.cache.get(cacheKey);
         if (!data) {
-            data = await this._sessionService.get(`/hasAccess/${sortedIds.join(',')}`);
+            if (!this.pendingHasAccessRequests[cacheKey]) {
+                this.pendingHasAccessRequests[cacheKey] = this._sessionService.get(`/hasAccess/${sortedIds.join(',')}`);
+            }
+            try {
+                data = await this.pendingHasAccessRequests[cacheKey];
+            } finally {
+                // If it rejects, we still want to clear the pending request
+                delete this.pendingHasAccessRequests[cacheKey];
+            }
             const expiresSeconds = data.ttl;
             this.cache.set(cacheKey, data, expiresSeconds * 1000);
         }

--- a/src/monetization.js
+++ b/src/monetization.js
@@ -107,14 +107,17 @@ export class Monetization extends EventEmitter {
             if (!this.pendingHasAccessRequests[cacheKey]) {
                 this.pendingHasAccessRequests[cacheKey] = this._sessionService.get(`/hasAccess/${sortedIds.join(',')}`);
             }
+            const promise = this.pendingHasAccessRequests[cacheKey];
             try {
-                data = await this.pendingHasAccessRequests[cacheKey];
+                data = await promise;
+                const expiresSeconds = data.ttl;
+                this.cache.set(cacheKey, data, expiresSeconds * 1000);
             } finally {
                 // If it rejects, we still want to clear the pending request
-                delete this.pendingHasAccessRequests[cacheKey];
+                if (this.pendingHasAccessRequests[cacheKey] === promise) {
+                    delete this.pendingHasAccessRequests[cacheKey];
+                }
             }
-            const expiresSeconds = data.ttl;
-            this.cache.set(cacheKey, data, expiresSeconds * 1000);
         }
 
         if (!data.entitled) {


### PR DESCRIPTION
# Description
If `Monetization.hasAccess` is called while another request is pending, there will be multiple calls to the (session service) backend.

This PR adds a check for this, and will await the same request for all concurrent calls.

Note: this happens in the wild (see www.e24.no), and will increase in the future.

# Testing
See initially failing unit test: 
* https://github.com/schibsted/account-sdk-browser/pull/307/files#diff-cf47c25e8b884e36479850fba29fab70efef4033ed6ff4508339f711b8ebb56fR110-R117
* https://github.com/schibsted/account-sdk-browser/actions/runs/21285542675/job/61265670932#step:6:19

